### PR TITLE
[feat/profile] 유저 프로필 사진 수정 기능 구현

### DIFF
--- a/src/components/my-owl/profile/Profile.tsx
+++ b/src/components/my-owl/profile/Profile.tsx
@@ -5,42 +5,6 @@ import styles from './Profile.module.css';
 import { createClient } from '@/utils/supabase/server';
 
 const Profile = async () => {
-  const supabase = createClient();
-
-  // authSNS, userId 제외한 요소는 supabase Auth가 아닌 supabse DB의 users에서 가져와야함.
-  const getUserData = async () => {
-    const {
-      data: { user },
-      error
-    } = await supabase.auth.getUser();
-
-    if (error) {
-      throw error;
-    }
-
-    if (user !== null) {
-      const { data, error } = await supabase.from('users').select('name, profile_url').eq('id', user.id).single();
-
-      if (error) {
-        throw error;
-      }
-
-      return {
-        authSNS: user.app_metadata.providers,
-        userInfo: {
-          userId: user.id,
-          name: data.name,
-          profileURL: data.profile_url
-        }
-      };
-    } else {
-      return {
-        authSNS: null,
-        userInfo: null
-      };
-    }
-  };
-
   const { userInfo, authSNS } = await getUserData();
   return (
     <div className={styles.profile_container}>
@@ -51,3 +15,39 @@ const Profile = async () => {
 };
 
 export default Profile;
+
+const supabase = createClient();
+
+// authSNS, userId 제외한 요소는 supabase Auth가 아닌 supabse DB의 users에서 가져와야함.
+export const getUserData = async () => {
+  const {
+    data: { user },
+    error
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    throw error;
+  }
+
+  if (user !== null) {
+    const { data, error } = await supabase.from('users').select('name, profile_url').eq('id', user.id).single();
+
+    if (error) {
+      throw error;
+    }
+
+    return {
+      authSNS: user.app_metadata.providers,
+      userInfo: {
+        userId: user.id,
+        name: data.name,
+        profileURL: data.profile_url
+      }
+    };
+  } else {
+    return {
+      authSNS: null,
+      userInfo: null
+    };
+  }
+};

--- a/src/components/my-owl/profile/editable/UserInfo.tsx
+++ b/src/components/my-owl/profile/editable/UserInfo.tsx
@@ -17,6 +17,7 @@ export interface UserInfoProps {
 const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
   const [editMode, setEditMode] = useState(false);
   const [userName, setUserName] = useState(name);
+  const [toggleModal, setToggleModal] = useState(false);
   //이름 바꾸고나서 이 state 가 업데이트가 안됨
 
   const handleChangeUserInfo = (event: ChangeEvent<HTMLInputElement>) => {
@@ -42,13 +43,17 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
     setEditMode(false);
   };
 
+  const handleToggleModal = () => {
+    setToggleModal((prev) => !prev);
+  };
+
   return (
     <div className={styles.user_container}>
       <div className={styles.profile_image} style={{ backgroundImage: `url(${profileURL})` }}>
         {editMode ? (
           <Image
             className={styles.edit}
-            onClick={() => {}}
+            onClick={handleToggleModal}
             src="/images/edit_mode.svg"
             alt="edit mode"
             width={24}

--- a/src/components/my-owl/profile/editable/UserInfo.tsx
+++ b/src/components/my-owl/profile/editable/UserInfo.tsx
@@ -79,7 +79,7 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
           </button>
         )}
       </div>
-      {toggleModal && <ImageUploadModal setToggleModal={setToggleModal} />}
+      {toggleModal && <ImageUploadModal handleToggleModal={handleToggleModal} />}
     </div>
   );
 };

--- a/src/components/my-owl/profile/editable/UserInfo.tsx
+++ b/src/components/my-owl/profile/editable/UserInfo.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, useState } from 'react';
 import styles from './UserInfo.module.css';
 import Image from 'next/image';
 import { createClient } from '@/utils/supabase/client';
+import { ImageUploadModal } from './modal/Modal';
 
 // import { supabase } from '@/shared/supabase';
 
@@ -78,6 +79,7 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
           </button>
         )}
       </div>
+      {toggleModal && <ImageUploadModal setToggleModal={setToggleModal} />}
     </div>
   );
 };

--- a/src/components/my-owl/profile/editable/modal/Modal.module.css
+++ b/src/components/my-owl/profile/editable/modal/Modal.module.css
@@ -1,0 +1,34 @@
+.background {
+  width: 100%;
+  height: 100%;
+
+  background-color: rgba(0, 0, 0, 0.4);
+
+  position: absolute;
+
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.modal {
+  width: 300px;
+
+  padding: 1.5rem 3rem;
+  border-radius: 10px;
+
+  gap: 10px;
+  display: flex;
+  flex-direction: column;
+
+  position: relative;
+  background-color: #ffffff;
+}
+
+.close_btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+
+  cursor: pointer;
+}

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -1,5 +1,64 @@
-import { Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
+import styles from './Modal.module.css';
 
-export const ImageUploadModal = ({ setToggleModal }: { setToggleModal: Dispatch<SetStateAction<boolean>> }) => {
-  return <></>;
+const MAX_FILE_SIZE_BYTE = 2097152; //2MB
+export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () => void }) => {
+  const [fileSizeExceed, setFileSizeExceed] = useState(false);
+
+  //util
+  const byteCalculater = (byte: number) => {
+    const KB = byte / 1024;
+    const MB = KB / 1024;
+    const GB = MB / 1024;
+    const TB = GB / 1024;
+
+    if (TB >= 1) {
+      return `${TB.toFixed(2)} TB`;
+    } else if (GB >= 1) {
+      return `${GB.toFixed(2)} GB`;
+    } else if (MB >= 1) {
+      return `${MB.toFixed(2)} MB`;
+    } else if (KB >= 1) {
+      return `${KB.toFixed(2)} KB`;
+    } else {
+      return `${byte} bytes`;
+    }
+  };
+
+  //util?
+  const handleFileMaxSize = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { files } = e.target;
+    if (files !== null) {
+      const size = files[0].size;
+      if (size > MAX_FILE_SIZE_BYTE) {
+        alert(
+          `선택하신 파일의 용량은 ${byteCalculater(size)}입니다. ${byteCalculater(
+            MAX_FILE_SIZE_BYTE
+          )} 이하의 파일을 골라주세요.`
+        );
+        setFileSizeExceed(true);
+      } else {
+        setFileSizeExceed(false);
+      }
+    } else console.log('no data');
+  };
+
+  return (
+    <div className={styles.background} onClick={handleToggleModal}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <form>
+          <input type="file" accept="image/jpeg,image/png,image/jpg" onChange={handleFileMaxSize} />
+          <button disabled={fileSizeExceed}>사진 업로드하기</button>
+        </form>
+        <p>또는</p>
+        <form>
+          <input type="url" placeholder="Paste link to an image..." />
+          <button>링크 첨부하기</button>
+        </form>
+        <div className={styles.close_btn} onClick={handleToggleModal}>
+          Exit
+        </div>
+      </div>
+    </div>
+  );
 };

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { MouseEvent, MouseEventHandler, useState } from 'react';
 import styles from './Modal.module.css';
 import { createClient } from '@/utils/supabase/client';
 
 const MAX_FILE_SIZE_BYTE = 2097152; //2MB
 
-export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () => void }) => {
+export const ImageUploadModal = async ({ handconstoggleModal }: { handconstoggleModal: () => void }) => {
   const [fileSizeExceed, setFileSizeExceed] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const supabase = createClient();
@@ -51,32 +51,43 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
     }
   };
 
+  const getFileName = () => {
+    const today = new Date();
+
+    const year = today.getFullYear(); // 년
+    const month = ('0' + (today.getMonth() + 1)).slice(-2); // 월
+    const date = ('0' + today.getDate()).slice(-2); // 일
+    const hours = today.getHours(); // 시
+    const minutes = today.getMinutes(); // 분
+    const seconds = today.getSeconds(); // 초
+
+    return `Owl_Photo_${year}-${month}-${date}-${hours}-${minutes}-${seconds}`;
+  };
+
   const uploadImage = async () => {
-    console.log('지금부터 이미지를 업로드 해볼게?');
+    const file_name = getFileName();
 
     if (file) {
-      const { data, error } = await supabase.storage.from('images').upload(`users_profile/${file.name}`, file);
-      console.log(error);
+      const { data, error } = await supabase.storage.from('images').upload(`users_profile/${file_name}`, file);
+      setFile(null);
       if (error) {
-        console.error('Error uploading image:', error.message);
-        console.log('에러났다구?');
+        alert(`이미지 업로드에 실패하였습니다.\n 원인 : ${error.message} `);
       } else {
-        console.log('ㅋㅋ');
-        console.log('Image uploaded successfully:', data);
-
-        setFile(null);
-        return `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${file.name}`;
+        handconstoggleModal();
+        return `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${file_name}`;
       }
     }
   };
 
-  const handleUploadImage = async () => {
+  const handleUploadImage = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     const profile_url = uploadImage();
+    console.log(profile_url);
     //profile_url
   };
 
   return (
-    <div className={styles.background} onClick={handleToggleModal}>
+    <div className={styles.background} onClick={handconstoggleModal}>
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <form>
           <input type="file" accept="image/jpeg,image/png,image/jpg" onChange={handleFileMaxSize} />
@@ -89,7 +100,7 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
           <input type="url" placeholder="Paste link to an image..." />
           <button>링크 첨부하기</button>
         </form>
-        <div className={styles.close_btn} onClick={handleToggleModal}>
+        <div className={styles.close_btn} onClick={handconstoggleModal}>
           Exit
         </div>
       </div>

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -1,9 +1,13 @@
 import { useState } from 'react';
 import styles from './Modal.module.css';
+import { createClient } from '@/utils/supabase/client';
 
 const MAX_FILE_SIZE_BYTE = 2097152; //2MB
+
 export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () => void }) => {
   const [fileSizeExceed, setFileSizeExceed] = useState(false);
+  const [file, setFile] = useState<File | null>(null);
+  const supabase = createClient();
 
   //util
   const byteCalculater = (byte: number) => {
@@ -30,6 +34,7 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
     const { files } = e.target;
     if (files !== null) {
       const size = files[0].size;
+      const file = files[0];
       if (size > MAX_FILE_SIZE_BYTE) {
         alert(
           `선택하신 파일의 용량은 ${byteCalculater(size)}입니다. ${byteCalculater(
@@ -39,8 +44,35 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
         setFileSizeExceed(true);
       } else {
         setFileSizeExceed(false);
+        setFile(file);
       }
-    } else console.log('no data');
+    } else {
+      console.log('no data');
+    }
+  };
+
+  const uploadImage = async () => {
+    console.log('지금부터 이미지를 업로드 해볼게?');
+
+    if (file) {
+      const { data, error } = await supabase.storage.from('images').upload(`users_profile/${file.name}`, file);
+      console.log(error);
+      if (error) {
+        console.error('Error uploading image:', error.message);
+        console.log('에러났다구?');
+      } else {
+        console.log('ㅋㅋ');
+        console.log('Image uploaded successfully:', data);
+
+        setFile(null);
+        return `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${file.name}`;
+      }
+    }
+  };
+
+  const handleUploadImage = async () => {
+    const profile_url = uploadImage();
+    //profile_url
   };
 
   return (
@@ -48,7 +80,9 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
       <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
         <form>
           <input type="file" accept="image/jpeg,image/png,image/jpg" onChange={handleFileMaxSize} />
-          <button disabled={fileSizeExceed}>사진 업로드하기</button>
+          <button disabled={fileSizeExceed} onClick={handleUploadImage}>
+            사진 업로드하기
+          </button>
         </form>
         <p>또는</p>
         <form>

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -1,0 +1,5 @@
+import { Dispatch, SetStateAction } from 'react';
+
+export const ImageUploadModal = ({ setToggleModal }: { setToggleModal: Dispatch<SetStateAction<boolean>> }) => {
+  return <></>;
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #7 
```
- 링크 첨부 로직은 아직 구현되지 않았습니다. 
- 프로필 사진의 경우, 취소 버튼 클릭 시 이전 프로필 사진이 적용되지 않습니다. 
  구현을 위해 임시 state를 마련했으나, 아직 활용하지 못했습니다. 
- 위 두가지의 미구현 기능은 supabase 관련된 코드가 정리 된 이후에 구현하도록 하겠습니다.
  가장 급한 기본 기능 우선 구현했으니 참고 부탁드립니다.
```
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 유저 프로필 사진 변경 시 확장자 제한 (.jpg, jpeg, .png)
- [x] 유저 프로필 사진 변경 시 크기 제한 (2MB)
- [x] 크기 초과 시, alert창을 통해 유저가 고른 파일 크기 및 최대 크기 정보 제공
- [x] 크기 초과 시, 사진 업로드하기 버튼 disabled
- [x] 프로필 사진 옆 연필 아이콘 클릭 시, 업로드 할 사진을 고르는 두 방식(paste link, upload)을 보여주는 모달 창 표시
  - [x] 모달 창 밖이나 Exit 버튼 클릭 시 모달 창 닫힘
- [x] supabase store 파일 이름 중복 방지용 파일 이름 생성 로직 작성 (이미지 저장 이름 형식 : Owl_Photo_2024-04-03-15-48-54)
## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
1. Modal.tsx 파일을 생성하여 아래의 기능들을 구현하였습니다.
- 용량 확인용 byte 변환기 byteCalculater
- 파일 용량 제한 로직 handleFileMaxSize
- 파일 이름 중복 방지용 파일 이름 생성 로직 getFileName
- supabase store 이미지 업로드 로직 uploadImage
- 유저 프로필 사진 업데이트 로직 changeUserProfile

```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
1. `uploadImage`가 작동하지 않는다?
   
    **[문제상황]**
    다음 태그 내에서 `사진 업로드하기` 버튼을 눌렀을 때, supabase store로 사진이 업로드 되어야 하는데, 동작하지 않는 문제가 발생했다.
    
    ```html
    <form>
         <input type="file" accept="image/jpeg,image/png,image/jpg" onChange={handleFileMaxSize} />
         <button disabled={fileSizeExceed} onClick={handleUploadImage}>
          사진 업로드하기
         </button>
     </form>
    ```
    
    **[원인파악]**
    form태그로 감싸져 있었기에, button을 눌렀을 때 제대로 동작하지 않았다. 

    **[해결]**
    handleUploadImage에 `e.preventDefault()`를 적용함으로서 해당 문제를 해결할 수 있었다.

2. 동작은 하는데… 에러라구요?

    **[문제상황]**
    1번 문제를 해결한 이후 코드 테스트를 해보았는데, `Error uploading image: new row violates row-level security policy` 오류가 발생하였다.
    이는 코드 자체의 문제는 아니고 firebase storage 권한 관련으로 인한 보안 정책 에러로 보인다. 

    **[원인파악]**
    해당 bucket이 public이 되어 있음에도 policy를 설정해주지 않으면 위와 같은 에러가 발생한다는 것을 알게 되었다.
    
    **[해결]**
    Storage Policy를 설정하고 다시 코드를 테스트해보니, 이미지가 정상적으로 업로드 되는 것을 확인할 수 있었다.

3. 사진을 여러번 올릴 때 이름이 겹치면 안돼! 어떤 이름을 쓰지?
    
    똑같은 이름을 가진 사진을 올리면 업로드가 안되는 문제가 발생했다.
    이를 해결하기 위해, 카카오톡에서 이미지를 다운로드 받을 때 어떻게 처리하는지 알아보았다.
    `KakaoTalk_Photo_2024-04-03-15-48-54` 
    
    KakaoTalk_Photo는 고정인 것 같다. 
    이미지 별 구분은 뒤에 오는 년-월-일-시-분-초로 하는 것으로 보인다.
    
    이 방법을 차용하여 이미지를 저장할 때 이름 형식을 다음과 같이 지정해보았다.
    
    `Owl_Photo_2024-04-03-15-48-54`
## 📸 스크린샷(선택)
![화면 기록 2024-04-03 오후 4 56 16](https://github.com/where-we-meet/owl/assets/69431340/cd163948-428f-47fe-8df2-cc7f7adfef50)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
1. input 태그에는 [file이라는 속성](https://hianna.tistory.com/346)이 있는데, 
이를 이용하면 웹페이지에서 사용자의 로컬 파일을 입력받을 수 있다.
    - 용량을 제한하는 것에 대해서는 [여기](https://ttowa.tistory.com/entry/JS-inputtypefile-%EC%9A%A9%EB%9F%89-%EC%A0%9C%ED%95%9C)를 첫 번째로, [여기](https://velog.io/@wuzoo/JS-%ED%8C%8C%EC%9D%BC-%EC%97%85%EB%A1%9C%EB%93%9C-%EC%8B%9C-%EC%9A%A9%EB%9F%89-%EC%B2%B4%ED%81%AC-%EB%AF%B8%EB%A6%AC%EB%B3%B4%EA%B8%B0-%EA%B5%AC%ED%98%84)를 두번째로 참고하였다.
2. 모달 버튼을 구현하는 방법은 [이 블로그](https://velog.io/@cloud_oort/Next.js-%EB%AA%A8%EB%8B%AC%EC%B0%BD-%EC%A0%95%EB%A7%90-%EC%89%BD%EA%B2%8C-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)를 참고하였다.
3. 사용하지는 않았지만, [mui](https://velog.io/@bami/MUI-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0)라는 것도 있더라. 
4. 리드미에 영상 업로드 하는 법 ([mp4 → gif](https://pgmjun.tistory.com/48))
## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
아직 에러 핸들링 로직이 온전치 않습니다. 
전반적으로 코드 분리가 필요한 상태라 파일 내 코드가 정신 없는데, 이를 분리한 이후에 
에러 핸들링 로직을 다시 깔끔하게 짜보면 좋을 것 같습니다.