### PR TITLE
[feat/userlist] realtime db를 적용하기 위하여 비즈니스 로직을 분리, 타입 이름을 직관적으로 변경

### DIFF
--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -1,11 +1,7 @@
 import Meeting from '@/components/room/meeting/Meeting';
-import { getRoomData } from '@/api/supabase';
 import Sidebar from '@/components/room/sidebar/Sidebar';
 
 const RoomPage = async ({ params }: { params: { id: string } }) => {
-  const data = await getRoomData(params.id);
-  console.log('roomData : ', data, 'id : ', params.id);
-
   return (
     <main style={{ display: 'flex' }}>
       <Sidebar id={params.id} />

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -3,25 +3,13 @@ import { getRealtimeRoomData, getRoomUsersData, getCurrentUserData } from '@/api
 import { userDataFetch } from '@/utils/supabase/userDataFetch';
 import { useEffect, useState } from 'react';
 
-export type Users = Awaited<ReturnType<typeof getRoomUsersData>>;
+export type RoomData = Awaited<ReturnType<typeof getRoomUsersData>>;
 
 const UserList = ({ id }: { id: string }) => {
-  const [roomData, setRoomData] = useState<Users>([]);
+  const [roomData, setRoomData] = useState<RoomData>([]);
 
   useEffect(() => {
     userDataFetch(id, setRoomData);
-    // const userData = async () => {
-    //   const { user } = await getCurrentUserData();
-    //   const userRoomData = await getRoomUsersData(id);
-    //   const currentUserId = user.id;
-
-    //   const adminUser = userRoomData.filter((user) => user.is_admin);
-    //   const currentUser = userRoomData.filter((user) => !user.is_admin && user.user_id === currentUserId);
-    //   const otherUsers = userRoomData.filter((user) => !user.is_admin && user.user_id !== currentUserId);
-
-    //   const sortedUsers = [...adminUser, ...currentUser, ...otherUsers];
-    //   setRoomData(sortedUsers);
-    // };
   }, [id]);
 
   return (

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { getRoomUsersData } from '@/api/supabase';
+import { getRealtimeRoomData, getRoomUsersData } from '@/api/supabase';
 import { userDataFetch } from '@/utils/supabase/userDataFetch';
 import { useEffect, useState } from 'react';
 
@@ -10,6 +10,8 @@ const UserList = ({ id }: { id: string }) => {
 
   useEffect(() => {
     userDataFetch(id, setRoomData);
+    getRealtimeRoomData(id, setRoomData);
+    console.log('실행됨?', getRealtimeRoomData(id, setRoomData));
   }, [id]);
 
   return (

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -9,8 +9,8 @@ const UserList = ({ id }: { id: string }) => {
   const [roomData, setRoomData] = useState<RoomData>([]);
 
   useEffect(() => {
-    userDataFetch(id, setRoomData);
     getRealtimeRoomData(id, setRoomData);
+    userDataFetch(id, setRoomData);
     console.log('실행됨?', getRealtimeRoomData(id, setRoomData));
   }, [id]);
 

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -1,19 +1,11 @@
 'use client';
 import { getRoomUsersData, getUserData } from '@/api/supabase';
-import { Tables } from '@/types/supabase';
 import { useEffect, useState } from 'react';
 
-type UserInfo = {
-  name: string;
-  profile_url: string | null;
-};
-
-type User = Tables<'userdata_room'> & {
-  users: UserInfo;
-};
+type Users = Awaited<ReturnType<typeof getRoomUsersData>>;
 
 const UserList = ({ id }: { id: string }) => {
-  const [users, setUsers] = useState<User[]>([]);
+  const [users, setUsers] = useState<Users>([]);
 
   useEffect(() => {
     const userData = async () => {
@@ -26,8 +18,7 @@ const UserList = ({ id }: { id: string }) => {
       const otherUsers = userRoomData.filter((user) => !user.is_admin && user.user_id !== currentUserId);
 
       const sortedUsers = [...adminUser, ...currentUser, ...otherUsers];
-
-      setUsers(sortedUsers as []);
+      setUsers(sortedUsers);
     };
     userData();
   }, [id]);
@@ -37,13 +28,15 @@ const UserList = ({ id }: { id: string }) => {
       <ul>
         {users.map((user) => {
           return (
-            <li key={user.id}>
-              <figure>
-                <div>{user.users.name}</div>
-                <img src={`${user.users.profile_url}`} alt="디폴트이미지" width={100} height={70} />
-              </figure>
-              <p>{user.start_location}</p>
-            </li>
+            user.users && (
+              <li key={user.id}>
+                <figure>
+                  <div>{user.users.name}</div>
+                  <img src={`${user.users.profile_url}`} alt="기본이미지" width={100} height={70} />
+                </figure>
+                <p>{user.start_location}</p>
+              </li>
+            )
           );
         })}
       </ul>

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { getRealtimeRoomData, getRoomUsersData, getCurrentUserData } from '@/api/supabase';
+import { getRoomUsersData } from '@/api/supabase';
 import { userDataFetch } from '@/utils/supabase/userDataFetch';
 import { useEffect, useState } from 'react';
 

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -1,32 +1,33 @@
 'use client';
-import { getRoomUsersData, getUserData } from '@/api/supabase';
+import { getRealtimeRoomData, getRoomUsersData, getCurrentUserData } from '@/api/supabase';
+import { userDataFetch } from '@/utils/supabase/userDataFetch';
 import { useEffect, useState } from 'react';
 
-type Users = Awaited<ReturnType<typeof getRoomUsersData>>;
+export type Users = Awaited<ReturnType<typeof getRoomUsersData>>;
 
 const UserList = ({ id }: { id: string }) => {
-  const [users, setUsers] = useState<Users>([]);
+  const [roomData, setRoomData] = useState<Users>([]);
 
   useEffect(() => {
-    const userData = async () => {
-      const { user } = await getUserData();
-      const userRoomData = await getRoomUsersData(id);
-      const currentUserId = user.id;
+    userDataFetch(id, setRoomData);
+    // const userData = async () => {
+    //   const { user } = await getCurrentUserData();
+    //   const userRoomData = await getRoomUsersData(id);
+    //   const currentUserId = user.id;
 
-      const adminUser = userRoomData.filter((user) => user.is_admin);
-      const currentUser = userRoomData.filter((user) => !user.is_admin && user.user_id === currentUserId);
-      const otherUsers = userRoomData.filter((user) => !user.is_admin && user.user_id !== currentUserId);
+    //   const adminUser = userRoomData.filter((user) => user.is_admin);
+    //   const currentUser = userRoomData.filter((user) => !user.is_admin && user.user_id === currentUserId);
+    //   const otherUsers = userRoomData.filter((user) => !user.is_admin && user.user_id !== currentUserId);
 
-      const sortedUsers = [...adminUser, ...currentUser, ...otherUsers];
-      setUsers(sortedUsers);
-    };
-    userData();
+    //   const sortedUsers = [...adminUser, ...currentUser, ...otherUsers];
+    //   setRoomData(sortedUsers);
+    // };
   }, [id]);
 
   return (
     <section>
       <ul>
-        {users.map((user) => {
+        {roomData.map((user) => {
           return (
             user.users && (
               <li key={user.id}>

--- a/src/utils/supabase/userDataFetch.ts
+++ b/src/utils/supabase/userDataFetch.ts
@@ -1,9 +1,9 @@
 'use client';
 
 import { getCurrentUserData, getRoomUsersData } from '@/api/supabase';
-import { Users } from '@/components/room/sidebar/user/UserList';
+import { RoomData } from '@/components/room/sidebar/user/UserList';
 
-export const userDataFetch = async (id: string, setRoomData: (users: Users) => void) => {
+export const userDataFetch = async (id: string, setRoomData: (roomData: RoomData) => void) => {
   const { user } = await getCurrentUserData();
   const userRoomData = await getRoomUsersData(id);
   const currentUserId = user.id;

--- a/src/utils/supabase/userDataFetch.ts
+++ b/src/utils/supabase/userDataFetch.ts
@@ -1,0 +1,17 @@
+'use client';
+
+import { getCurrentUserData, getRoomUsersData } from '@/api/supabase';
+import { Users } from '@/components/room/sidebar/user/UserList';
+
+export const userDataFetch = async (id: string, setRoomData: (users: Users) => void) => {
+  const { user } = await getCurrentUserData();
+  const userRoomData = await getRoomUsersData(id);
+  const currentUserId = user.id;
+
+  const adminUser = userRoomData.filter((user) => user.is_admin);
+  const currentUser = userRoomData.filter((user) => !user.is_admin && user.user_id === currentUserId);
+  const otherUsers = userRoomData.filter((user) => !user.is_admin && user.user_id !== currentUserId);
+
+  const sortedUsers = [...adminUser, ...currentUser, ...otherUsers];
+  setRoomData(sortedUsers);
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#18 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] userdata_room 테이블을 realtime으로 구현
- [x] users 테이블의 name, profile_url을 realtime으로 구현
- [x] UserList 컴포넌트 내부에 존재하는 비즈니스 로직을 분리
- [x] supabase.ts 내부의 기능들을 정리하여 외부에서 호출만으로 사용할 수 있도록 분리

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
realtime db를 사용시 클린업으로 구독을 해지하는 기능을 삽입하는 것이 권장됩니다. 따라서 기존 로직을 분리하였습니다. 
또한 직관적인 타입을 위하여 Users 타입의 이름을 RoomData로 변경하였습니다.
realtime을 적용하여 userdata_room의 데이터를 반영할 수 있게 되었습니다.
```
##  TroubleShootting
<!-- TroubleShootting이 있었다면 이야기 해주세요! -->
```
현재 realtime db를 사용하며, 적용하는 부분에 있어서 어려움을 겪고 있습니다.
```
## 📸 스크린샷(선택)

![분리로직](https://github.com/where-we-meet/owl/assets/109938441/41e42880-4356-4506-be9c-cfe58cb2913c)
![분리로직2](https://github.com/where-we-meet/owl/assets/109938441/d5577810-2713-4292-a45d-2e13a8ee51e7)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
realtime db에서 필요한 기능 중, 변동사항을 payload를 콜백함수로 가져 올 수 있는데 이 기능에 대해서 조금 더 공부가 필요 할 것 같습니다.

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->

