### PR TITLE
[feat/meeting] 모임 방 정보 조회 및 이동 구현

### DIFF
--- a/src/app/my-owl/page.tsx
+++ b/src/app/my-owl/page.tsx
@@ -1,9 +1,11 @@
-import Profile from "@/components/my-owl/profile/Profile";
+import { Meeting } from '@/components/my-owl/meeting/Meeting';
+import Profile from '@/components/my-owl/profile/Profile';
 
 export default function MyOwl() {
   return (
-    <main>
+    <main style={{ display: 'flex' }}>
       <Profile />
+      <Meeting />
     </main>
   );
 }

--- a/src/components/my-owl/meeting/Meeting.module.css
+++ b/src/components/my-owl/meeting/Meeting.module.css
@@ -3,12 +3,13 @@
   background-color: gray;
 
   height: 80vh;
+  width: 70vw;
+
   overflow-y: scroll;
 }
 
 .rooms_box {
-  padding: 20px;
-  width: 500px;
+  padding: 10px;
 
   display: flex;
   flex-direction: column;
@@ -17,9 +18,40 @@
 .room_box {
   padding: 20px;
   border-radius: 10px;
+  height: 100%;
 
   display: flex;
   justify-content: space-between;
+  align-items: center;
 
   background-color: white;
+}
+
+.room_box_left {
+  text-align: left;
+  line-height: 25px;
+}
+
+.room_box_right {
+  text-align: right;
+
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+}
+
+.participants_container {
+  display: flex;
+  justify-content: right;
+  align-items: center;
+
+  gap: 5px;
+}
+
+.participant_profile {
+  width: 20px;
+  height: 20px;
+
+  background-size: cover;
+  background-position: center;
 }

--- a/src/components/my-owl/meeting/Meeting.module.css
+++ b/src/components/my-owl/meeting/Meeting.module.css
@@ -1,0 +1,25 @@
+.meeting_container {
+  margin: 20px;
+  background-color: gray;
+
+  height: 80vh;
+  overflow-y: scroll;
+}
+
+.rooms_box {
+  padding: 20px;
+  width: 500px;
+
+  display: flex;
+  flex-direction: column;
+}
+
+.room_box {
+  padding: 20px;
+  border-radius: 10px;
+
+  display: flex;
+  justify-content: space-between;
+
+  background-color: white;
+}

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -1,29 +1,112 @@
-import { createClient } from '@/utils/supabase/server';
+'use client';
+import { createClient } from '@/utils/supabase/client';
 import styles from './Meeting.module.css';
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
 
-const supabase = createClient();
+interface UserInfo {
+  name: string;
+  profile_url: string;
+}
+
+interface MeetingInfo {
+  name: string | null;
+  location: string | null;
+  participants: UserInfo[];
+}
+
 export const Meeting = () => {
-  const getUserInfo = async () => {};
-  const getUserMeetings = async () => {
-    const { data, error } = await supabase.from('room_schedule').select('room_id, start_date, end_date, created_by');
-  };
+  const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
+
+  useEffect(() => {
+    const fetchMeetingInfo = async () => {
+      const meetingIds = await getUserMeetingsId();
+      const meetingInfoPromises = meetingIds.map(async (meetingId) => {
+        const roomId = meetingId.room_id;
+        const roomInfo = await getRoomInfo(roomId);
+        const participantsIds = await getRoomParticipantsId(roomId);
+        const participantsInfoPromises = participantsIds.map(async (participantId) => {
+          const userInfo = await getUserInfo(participantId.user_id);
+          return userInfo[0];
+        });
+        const participantsInfo = await Promise.all(participantsInfoPromises);
+        return {
+          name: roomInfo[0].name,
+          location: roomInfo[0].location,
+          participants: participantsInfo
+        };
+      });
+      const fetchedMeetingInfo = await Promise.all(meetingInfoPromises);
+      setMeetingInfo(fetchedMeetingInfo.filter((meeting) => meeting !== null) as MeetingInfo[]);
+    };
+
+    fetchMeetingInfo();
+  }, []);
+
   return (
     <div className={styles.meeting_container}>
-      <div className={styles.rooms_box}>
-        <div className={styles.room_box}>
-          <div>
-            <h3>모임명</h3>
-            <p>날짜</p>
-            <p>위치</p>
-          </div>
-          <div>
-            <div>
-              <p>user들의 프로필사진</p>
+      {meetingInfo.map((meeting, index) => (
+        <div key={index} className={styles.rooms_box}>
+          <div className={styles.room_box}>
+            <div className={styles.room_box_left}>
+              <h3>{meeting.name}</h3>
+              <p>날짜</p>
+              <p>위치 : {meeting.location}</p>
             </div>
-            <p>n명 참여중</p>
+            <div className={styles.room_box_right}>
+              <div className={styles.participants_container}>
+                {meeting.participants.map((participant, index) => (
+                  <div
+                    className={styles.participant_profile}
+                    style={{ backgroundImage: `url(${participant.profile_url})` }}
+                    key={index}
+                  />
+                ))}
+              </div>
+              <p>{meeting.participants.length}명 참여중</p>
+            </div>
           </div>
         </div>
-      </div>
+      ))}
     </div>
   );
+};
+
+const supabase = createClient();
+
+const getUserId = async () => {
+  const {
+    data: { user },
+    error
+  } = await supabase.auth.getUser();
+  if (error) throw error;
+  return user !== null ? user.id : null;
+};
+
+const getUserMeetingsId = async () => {
+  const userId = await getUserId();
+  if (userId !== null) {
+    const { data, error } = await supabase.from('userdata_room').select('room_id').eq('user_id', userId);
+    if (error) throw error;
+    return data;
+  }
+  return [];
+};
+
+const getRoomInfo = async (roomId: string) => {
+  const { data, error } = await supabase.from('rooms').select('name, location').eq('id', roomId);
+  if (error) throw error;
+  return data;
+};
+
+const getRoomParticipantsId = async (roomId: string) => {
+  const { data, error } = await supabase.from('userdata_room').select('user_id').eq('room_id', roomId);
+  if (error) throw error;
+  return data;
+};
+
+const getUserInfo = async (userId: string) => {
+  const { data, error } = await supabase.from('users').select('name, profile_url').eq('id', userId);
+  if (error) throw error;
+  return data;
 };

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -1,0 +1,24 @@
+import styles from './Meeting.module.css';
+
+export const Meeting = () => {
+  const getUserMeetings = () => {};
+  return (
+    <div className={styles.meeting_container}>
+      <div className={styles.rooms_box}>
+        <div className={styles.room_box}>
+          <div>
+            <h3>모임명</h3>
+            <p>날짜</p>
+            <p>위치</p>
+          </div>
+          <div>
+            <div>
+              <p>user들의 프로필사진</p>
+            </div>
+            <p>n명 참여중</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -1,7 +1,12 @@
+import { createClient } from '@/utils/supabase/server';
 import styles from './Meeting.module.css';
 
+const supabase = createClient();
 export const Meeting = () => {
-  const getUserMeetings = () => {};
+  const getUserInfo = async () => {};
+  const getUserMeetings = async () => {
+    const { data, error } = await supabase.from('room_schedule').select('room_id, start_date, end_date, created_by');
+  };
   return (
     <div className={styles.meeting_container}>
       <div className={styles.rooms_box}>

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -64,7 +64,6 @@ export const Meeting = () => {
               <h3>{meeting.name}</h3>
               <p>날짜</p>
               <p>위치 : {meeting.location}</p>
-              <p>방 생성일 : {meeting.created_at}</p>
             </div>
             <div className={styles.room_box_right}>
               <div className={styles.participants_container}>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #8 #9 
```
모임 컨테이너 클릭 시, 프로필 수정 중에 있었다면 유저에게 변경사항 저장을 물어보기 는 
상태 관리 위치를 바꾸어야 하므로, feature/myowl-profile branch merge 이후에 구현이 가능합니다. 
```
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 유저가 참여하고 있는 모임 방에 대한 정보를 리스트로 보여주기
- [x] 모임 방 컨테이너 클릭 시, 해당 모임 방으로 이동
- [x] 확정된 일정을 1순위로, 최근에 생성된 모임을 2순위로 하여 모임 정렬

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
- 현재까지 제공된 와이어프레임을 기준으로 기본적인 UI 틀을 만들었습니다. 
  - overflow-y:scroll 속성을 적용했습니다.
- 유저가 참여하고 있는 모임 방에 대한 정보들을 가져오는 로직을 useEffect로 구현하였습니다.
- 모임 방 컨테이너 클릭 시, 해당 모임 방으로 이동하도록 구현하였습니다. 
  - useRouter() : next/navigation을 사용하였습니다.
- created_at과 verified을 기준으로 meetingInfo를 정렬하는 함수를 만들었습니다. 
  정렬 우선순위는 아래와 같습니다.
  - 1순위 : verified가 true
  - 2순위 : created_at이 가장 빠른 날짜

```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
```
전반적으로 비동기 처리와 관련하여 Type에 대한 문제가 많았습니다. 
현재는 기능을 구현하는 것 자체가 우선순위라 시간 단축을 위해 GPT에게 많은 힌트를 얻어 문제를 해결 하였는데, 
추후 리팩터링을 하며 제 스타일이 잘 드러나는 코드로 개선하고 싶네요.
```
## 📸 스크린샷(선택)
![화면 기록 2024-04-04 오전 2 27 06](https://github.com/where-we-meet/owl/assets/69431340/83d4263a-47aa-4413-9163-ab1757160ce7)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
1. [promise.all()](https://velog.io/@jay2u8809/Promise.all-%EB%A1%9C-%EB%B9%84%EB%8F%99%EA%B8%B0-%EC%B2%98%EB%A6%AC%EB%A5%BC-%EA%B5%AC%ED%98%84%ED%95%B4-%EB%B3%B4%EC%9E%90)로 비동기 처리 구현하기
## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
