### PR TITLE
fix: 로그인 페이지 헤더 숨기기

### DIFF
--- a/src/app/login/page.module.css
+++ b/src/app/login/page.module.css
@@ -1,9 +1,15 @@
 .main {
+  position: absolute;
+  top: 0;
+  left: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   min-height: 100vh;
+  background: white;
+  width: 100%;
+  height: 100%;
 }
 
 .hero {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,13 +2,8 @@ import { createClient } from '@/utils/supabase/server';
 import Logout from '../auth/LogoutButton';
 import styles from './Header.module.css';
 import Link from 'next/link';
-import { headers } from 'next/headers';
 
 const Header = async () => {
-  const headersList = headers();
-  const fullUrl = headersList.get('referer') || '';
-  if (fullUrl.split('/')[3] === 'login') return null;
-
   const supabase = await createClient();
 
   const {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#55

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 로그인페이지 헤더 숨기기

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
const headersList = headers();
const fullUrl = headersList.get('referer') || '';
if (fullUrl.split('/')[3] === 'login') return null;
```
다른페이지에서 로그인페이지로 이동하면 header 서버 컴포넌트는 그대로 가져오기때문에 변경되지 않음.
그냥 `position absolute`로 덮어씌우기

##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->

## 📸 스크린샷(선택)
![image](https://github.com/where-we-meet/owl/assets/85791020/7195fdbb-2778-4339-ad09-a85c8c3087e5)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
로그인페이지에서 헤더 메뉴 보이는지 테스트