### PR TITLE
[Fix/room-set_location] 검색 결과 선택 외 방법으로 유저 위치 값 못 가져오는 이슈 수정, 유저 위치 초기에 pin에 loading 표시

### DIFF
--- a/src/components/room/meeting/place/KakaoMap.tsx
+++ b/src/components/room/meeting/place/KakaoMap.tsx
@@ -38,7 +38,6 @@ const KakaoMap = () => {
           <RangeController center={userLocationData.location} />
         </Map>
       </div>
-      <div>{`lat: ${userLocationData.location.lat} lng: ${userLocationData.location.lng}`}</div>
       <div>{userLocationData.address}</div>
     </div>
   );

--- a/src/components/room/meeting/place/KakaoMap.tsx
+++ b/src/components/room/meeting/place/KakaoMap.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { Map } from 'react-kakao-maps-sdk';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
-import { useCenterState } from '@/hooks/useCenterState';
+import { useMapController } from '@/hooks/useMapController';
 
 import RangeController from './RangeController';
 import styles from './KakaoMap.module.css';
@@ -9,7 +9,7 @@ import styles from './KakaoMap.module.css';
 const KakaoMap = () => {
   const [loading, error] = useKakaoMap();
 
-  const { userLocationData, handleChangeCenter, isGpsLoading, isDrag, setIsDrag, errorMassage } = useCenterState();
+  const { userLocationData, handleChangeCenter, isGpsLoading, isDrag, setIsDrag, errorMassage } = useMapController();
 
   if (loading) return <div>loading...</div>;
   if (error) return <div>error</div>;

--- a/src/components/room/meeting/place/KakaoMap.tsx
+++ b/src/components/room/meeting/place/KakaoMap.tsx
@@ -9,7 +9,7 @@ import styles from './KakaoMap.module.css';
 const KakaoMap = () => {
   const [loading, error] = useKakaoMap();
 
-  const { centerData, handleChangeCenter, isGpsLoading, isDrag, setIsDrag, errorMassage } = useCenterState();
+  const { userLocationData, handleChangeCenter, isGpsLoading, isDrag, setIsDrag, errorMassage } = useCenterState();
 
   if (loading) return <div>loading...</div>;
   if (error) return <div>error</div>;
@@ -29,17 +29,17 @@ const KakaoMap = () => {
           />
         )}
         <Map
-          center={centerData.location}
+          center={userLocationData.location}
           className={styles.map}
           onCenterChanged={(map) => handleChangeCenter(map)}
           onDragStart={() => setIsDrag(true)}
           onDragEnd={() => setIsDrag(false)}
         >
-          <RangeController center={centerData.location} />
+          <RangeController center={userLocationData.location} />
         </Map>
       </div>
-      <div>{`lat: ${centerData.location.lat} lng: ${centerData.location.lng}`}</div>
-      <div>{centerData.address}</div>
+      <div>{`lat: ${userLocationData.location.lat} lng: ${userLocationData.location.lng}`}</div>
+      <div>{userLocationData.address}</div>
     </div>
   );
 };

--- a/src/components/room/meeting/place/LocationPicker.tsx
+++ b/src/components/room/meeting/place/LocationPicker.tsx
@@ -1,20 +1,18 @@
+import { useParams } from 'next/navigation';
 import { getCurrentUserData, updateStartLocation } from '@/api/supabaseCSR/supabase';
 import { useSearchDataStore } from '@/store/store';
-import { useParams } from 'next/navigation';
 
 const LocationPicker = () => {
   const { id: roomId }: { id: string } = useParams();
-  const searchCenter = useSearchDataStore((state) => state.center);
+  const address = useSearchDataStore((state) => state.address);
 
   const handleSubmitLocation = async () => {
     const {
       user: { id: userId }
     } = await getCurrentUserData();
-    if (roomId && userId && searchCenter) {
-      console.log('roomId => ', roomId, 'userId => ', userId, 'searchCenter => ', searchCenter);
-      await updateStartLocation(roomId, userId, searchCenter.addressName);
+    if (roomId && userId && address) {
+      await updateStartLocation(roomId, userId, address);
     } else {
-      console.log('roomId => ', roomId, 'userId => ', userId, 'searchCenter => ', searchCenter);
       alert('no');
     }
   };

--- a/src/components/room/meeting/place/search/SearchResultList.tsx
+++ b/src/components/room/meeting/place/search/SearchResultList.tsx
@@ -17,7 +17,7 @@ const SearchResultList = ({
     }>
   >;
 }) => {
-  const setCenter = useSearchDataStore((state) => state.setCenter);
+  const setLocation = useSearchDataStore((state) => state.setLocation);
 
   const handleListFocus = (event: MouseEvent<HTMLDivElement>) => {
     event.stopPropagation();
@@ -26,7 +26,7 @@ const SearchResultList = ({
 
   const handleChangeViewPoint = (place: Place) => {
     const point = changeToViewPoint(place);
-    setCenter(point);
+    setLocation(point);
   };
   return (
     <div className={styles.places_container} onMouseEnter={handleListFocus} onMouseLeave={handleListFocus}>

--- a/src/hooks/useCenterState.ts
+++ b/src/hooks/useCenterState.ts
@@ -1,48 +1,55 @@
-import { CenterData } from '@/types/place.types';
-import { useEffect, useState } from 'react';
+import { useGetRoadAddress } from '@/hooks/useGetPlace';
+import { useCallback, useEffect, useState } from 'react';
+import { useSearchDataStore } from '@/store/store';
+import _ from 'lodash';
 
 export const useCenterState = () => {
-  const [centerData, setCenterData] = useState<CenterData>({
-    center: {
-      lat: 33.450701,
-      lng: 126.570667
-    },
-    errMsg: null,
-    isLoading: true,
-    roadAddress: null
-  });
+  const [isGpsLoading, setIsGpsLoading] = useState(true);
+  const [errorMassage, setErrorMassage] = useState('');
+  const [isDrag, setIsDrag] = useState(false);
+
+  const userLocationData = useSearchDataStore((state) => state);
+  const setLocation = useSearchDataStore((state) => state.setLocation);
+  const setAddress = useSearchDataStore((state) => state.setAddress);
+
+  const { data, isPending } = useGetRoadAddress(userLocationData.location, isDrag);
+
+  const setCenter = (map: kakao.maps.Map) => {
+    const latlng = map.getCenter();
+    setLocation({ lat: latlng.getLat(), lng: latlng.getLng() });
+  };
+
+  const handleChangeCenter = useCallback(_.debounce(setCenter, 1000), []);
 
   useEffect(() => {
     if (navigator.geolocation) {
       // GeoLocation을 이용해서 접속 위치를 얻어옵니다
       navigator.geolocation.getCurrentPosition(
         (position) => {
-          setCenterData((prev) => ({
-            ...prev,
-            center: {
-              lat: position.coords.latitude, // 위도
-              lng: position.coords.longitude // 경도
-            },
-            isLoading: false
-          }));
+          setLocation({
+            lat: position.coords.latitude, // 위도
+            lng: position.coords.longitude // 경도
+          });
+          setIsGpsLoading(false);
         },
         (err) => {
-          setCenterData((prev) => ({
-            ...prev,
-            errMsg: err.message,
-            isLoading: false
-          }));
+          setErrorMassage(err.message);
+          setIsGpsLoading(false);
         }
       );
     } else {
       // HTML5의 GeoLocation을 사용할 수 없을때 마커 표시 위치와 인포윈도우 내용을 설정합니다
-      setCenterData((prev) => ({
-        ...prev,
-        errMsg: 'geolocation을 사용할수 없어요..',
-        isLoading: false
-      }));
+      setErrorMassage('geolocation을 사용할수 없어요..');
+      setIsGpsLoading(false);
     }
   }, []);
 
-  return { centerData, setCenterData };
+  useEffect(() => {
+    if (data) {
+      const address = data.road_address?.address_name || data.address?.address_name;
+      setAddress(address);
+    }
+  }, [data]);
+
+  return { userLocationData, setLocation, handleChangeCenter, isGpsLoading, isDrag, setIsDrag, errorMassage };
 };

--- a/src/hooks/useGetPlace.ts
+++ b/src/hooks/useGetPlace.ts
@@ -1,11 +1,11 @@
 import { getAddress, getSearchPlace } from '@/api/place/placeData';
 import { useQuery } from '@tanstack/react-query';
 
-export const useGetRoadAddress = (center: { lat: number; lng: number }) => {
+export const useGetRoadAddress = (location: { lat: number; lng: number }, isDrag: boolean) => {
   const { data, isPending } = useQuery({
-    queryKey: ['room', center],
-    queryFn: async () => await getAddress(center),
-    enabled: !!center
+    queryKey: ['room', location],
+    queryFn: async () => await getAddress(location),
+    enabled: !!location && !isDrag
   });
   return { data, isPending };
 };

--- a/src/hooks/useMapController.ts
+++ b/src/hooks/useMapController.ts
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useSearchDataStore } from '@/store/store';
 import _ from 'lodash';
 
-export const useCenterState = () => {
+export const useMapController = () => {
   const [isGpsLoading, setIsGpsLoading] = useState(true);
   const [errorMassage, setErrorMassage] = useState('');
   const [isDrag, setIsDrag] = useState(false);

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,19 +1,26 @@
 import { create } from 'zustand';
 
 type State = {
-  center: {
-    name: string;
-    addressName: string;
+  location: {
     lat: number;
     lng: number;
-  } | null;
+  };
+  address?: string;
+  addressName?: string;
 };
 
 type Action = {
-  setCenter: (point: State['center']) => void;
+  setLocation: (location: State['location']) => void;
+  setAddress: (address: State['address']) => void;
 };
 
 export const useSearchDataStore = create<State & Action>((set) => ({
-  center: null,
-  setCenter: (point) => set(() => ({ center: point }))
+  location: {
+    lat: 33.450701,
+    lng: 126.570667
+  },
+  address: '',
+  addressName: '',
+  setLocation: (location) => set({ location }),
+  setAddress: (address) => set({ address })
 }));

--- a/src/utils/place/dragCenter.ts
+++ b/src/utils/place/dragCenter.ts
@@ -1,7 +1,0 @@
-import type { CenterData } from '@/types/place.types';
-import type { SetStateAction, Dispatch } from 'react';
-
-export const dragCenter = (map: kakao.maps.Map, setStater: Dispatch<SetStateAction<CenterData>>) => {
-  const latlng = map.getCenter();
-  setStater((prev) => ({ ...prev, center: { lat: latlng.getLat(), lng: latlng.getLng() } }));
-};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #47 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 유저 위치 값 전역으로 관리
- [x] 위치 값 이 가지고 있는 데이터 변수명 수정
- [x] 위치값 전역 상태관리로 인한 state update 로직 수정

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
  초기 현재 유저의 위치 정보를 가져올 때 시간이 걸림
  => pin 위치에 임시로 loading... 문구 적용 / 추후에 스피너로 대체 하면 좋을 것 같음

  const userLocationData = useSearchDataStore((state) => state);
   => store에서 유저의 위치 정보를 가져옵니다. (location, address, addressName)

  const setLocation = useSearchDataStore((state) => state.setLocation);
  const setAddress = useSearchDataStore((state) => state.setAddress);
   => store에서 위치와 주소 state를 변경할 setter 함수를 가져옵니다.

  useMapController 커스텀 훅으로 서비스 로직 분리
```
##  TroubleShotting
<!-- TroubleShotting이 있었다면 이야기 해주세요! -->
```
지도가 움직이면 중심이 실시간으로 바뀌어 위치 값 state가 변경됨 => 위치 관련된 컴포넌트 리렌더링
=> debounce 사용하여 최종의 위치값만 set state 함
debounce를 적용했다보니 드래그를 하다가 잠시 멈춰 있으면 위치값이 변하지 않아 위치 값이 set state 되고 현재 위치 기반의 주소를 fetch 해옴
=> drag 상태값을 사용하여 useQuery enabled 옵션에 location 값 유무와 drag 상태를 비교하여 data fetching 함
```
## 📸 스크린샷(선택)

![owl-유저 위치 수정본](https://github.com/where-we-meet/owl/assets/100992153/d6e2823f-404f-4e9e-b2eb-b976f0349eff)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
새로운 버그가 있다면 이슈를 만들어주세요 ㅜㅜ
