### PR TITLE
[Feature/room-user_marker] 지도에 유저들 위치 marker 표시, roomUsers 전역 관리

### DIFF
--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -5,11 +5,10 @@ import Sidebar from '@/components/room/sidebar/Sidebar';
 import { useGetRoomData } from '@/hooks/useGetRoomData';
 
 const RoomPage = ({ params }: { params: { id: string } }) => {
-  const { roomUsers } = useGetRoomData(params.id);
-
+  useGetRoomData(params.id);
   return (
     <main style={{ display: 'flex' }}>
-      <Sidebar roomUsers={roomUsers} />
+      <Sidebar />
       <Meeting id={params.id} />
     </main>
   );

--- a/src/components/room/meeting/place/KakaoMap.tsx
+++ b/src/components/room/meeting/place/KakaoMap.tsx
@@ -5,11 +5,14 @@ import { useMapController } from '@/hooks/useMapController';
 
 import RangeController from './RangeController';
 import styles from './KakaoMap.module.css';
+import UserMarker from './UserMarker';
+import { useRoomUserDataStore } from '@/store/store';
 
 const KakaoMap = () => {
   const [loading, error] = useKakaoMap();
-
   const { userLocationData, handleChangeCenter, isGpsLoading, isDrag, setIsDrag, errorMassage } = useMapController();
+
+  const roomUsers = useRoomUserDataStore((state) => state.roomUsers);
 
   if (loading) return <div>loading...</div>;
   if (error) return <div>error</div>;
@@ -35,6 +38,7 @@ const KakaoMap = () => {
           onDragStart={() => setIsDrag(true)}
           onDragEnd={() => setIsDrag(false)}
         >
+          {roomUsers.map(({ id, lat, lng }) => lat && lng && <UserMarker key={id} id={id} lat={lat} lng={lng} />)}
           <RangeController center={userLocationData.location} />
         </Map>
       </div>

--- a/src/components/room/meeting/place/UserMarker.tsx
+++ b/src/components/room/meeting/place/UserMarker.tsx
@@ -1,0 +1,19 @@
+import { MapMarker } from 'react-kakao-maps-sdk';
+
+const UserMarker = ({ id, lat, lng }: { id: string; lat: string; lng: string }) => {
+  return (
+    <MapMarker
+      key={id}
+      position={{ lat: +lat, lng: +lng }}
+      image={{
+        src: '/pin.svg',
+        size: {
+          width: 50,
+          height: 50
+        }
+      }}
+    />
+  );
+};
+
+export default UserMarker;

--- a/src/components/room/sidebar/Sidebar.tsx
+++ b/src/components/room/sidebar/Sidebar.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
 
-import { RoomUser } from '@/types/roomUser';
-
 import style from './Sidebar.module.css';
 import UserList from './user/UserList';
 
-const Sidebar = ({ roomUsers }: { roomUsers: RoomUser[] }) => {
+const Sidebar = () => {
   return (
     <div className={style.container}>
       <section>
@@ -15,7 +13,7 @@ const Sidebar = ({ roomUsers }: { roomUsers: RoomUser[] }) => {
           <button>공유하기</button>
         </div>
       </section>
-      <UserList roomUsers={roomUsers} />
+      <UserList />
     </div>
   );
 };

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { RoomUser } from '@/types/roomUser';
+import { useRoomUserDataStore } from '@/store/store';
 
-const UserList = ({ roomUsers }: { roomUsers: RoomUser[] }) => {
+const UserList = () => {
+  const roomUsers = useRoomUserDataStore((state) => state.roomUsers);
   return (
     <section>
       <ul>

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,20 +1,24 @@
+import type { RoomUser } from '@/types/roomUser';
 import { create } from 'zustand';
 
-type State = {
+type Location = {
   location: {
     lat: number;
     lng: number;
   };
   address: string;
   addressName?: string;
+  setLocation: (location: Location['location']) => void;
+  setAddress: (address: Location['address']) => void;
 };
 
-type Action = {
-  setLocation: (location: State['location']) => void;
-  setAddress: (address: State['address']) => void;
+type RoomUserData = {
+  roomUsers: RoomUser[];
+  setRoomUsers: (roomUsers: RoomUser[]) => void;
+  updateRoomUserData: (payload: RoomUser) => void;
 };
 
-export const useSearchDataStore = create<State & Action>((set) => ({
+export const useSearchDataStore = create<Location>((set) => ({
   location: {
     lat: 33.450701,
     lng: 126.570667
@@ -23,4 +27,17 @@ export const useSearchDataStore = create<State & Action>((set) => ({
   addressName: '',
   setLocation: (location) => set({ location }),
   setAddress: (address) => set({ address })
+}));
+
+export const useRoomUserDataStore = create<RoomUserData>((set) => ({
+  roomUsers: [],
+  setRoomUsers: (roomUsers) => set({ roomUsers }),
+  updateRoomUserData: (payload) =>
+    set((state) => ({
+      roomUsers: state.roomUsers.map((user) =>
+        user.id === payload.id
+          ? { ...user, start_location: payload.start_location, lat: payload.lat, lng: payload.lng }
+          : user
+      )
+    }))
 }));

--- a/src/types/roomUser.ts
+++ b/src/types/roomUser.ts
@@ -4,6 +4,8 @@ export type RoomUser = {
   is_admin: boolean;
   room_id: string;
   start_location: string | null;
+  lat: string | null;
+  lng: string | null;
   user_id: string;
   users: {
     profile_url: string | null;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #63 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] db에 유저 시작 위치 data map의 marker 와 연결
- [x] useGetRoomData에서 지역 state 전역 state로 적용
- [ ] 유저 위치 지정하면 map 중간의 위치 설정용 pin 제거

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
useGetRoomData의 roomUser 지역 상태 전역 상태로 변경하면서 관련 prop drilling 및 import 경로 수정
store 에서 가져온 roomUsers 데이터로 지도에 유저들 선택한 위치 marker 표시

아직 유저가 위치를 지정하면 설정용 pin UI 제거는 못함
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
useGetRoomData의 useEffect 안에서  store에서 가져온 roomUsers에 realtime으로 구독한 payload.new를 가공해 newRoomUsers를 만들어 setRoomUsers(newRoomUsers) setter 함수를 사용해 state를 변경하려했지만 roomUsers가 초기값 빈배열로만 나와 업데이트가 안되는 상황이 발생
=> zustand store에서 변경된 payload.new를 가져와 state를 변경하면서 해결
```
## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
