### PR TITLE
[Fix/halfway] calcCenterPoint.ts 반환 타입 맞추기, 타입 수정 및 적용

### DIFF
--- a/src/hooks/useGetHalfway.ts
+++ b/src/hooks/useGetHalfway.ts
@@ -1,11 +1,13 @@
-import { useRoomUserDataStore } from '@/store/store';
-import type { RoomUser } from '@/types/roomUser';
-import calcCenterPoint from '@/utils/place/calcCenterPoint';
-import convexHull from '@/utils/place/convexHull';
 import { useEffect, useState } from 'react';
 
+import calcCenterPoint from '@/utils/place/calcCenterPoint';
+import convexHull from '@/utils/place/convexHull';
+
+import type { Halfway } from '@/types/place.types';
+import type { RoomUser } from '@/types/roomUser';
+
 export const useGetHalfway = (roomUsers: RoomUser[]) => {
-  const [halfwayPoint, setHalfwayPoint] = useState({ lat: 0, lng: 0 });
+  const [halfwayPoint, setHalfwayPoint] = useState<Halfway>({ lat: null, lng: null });
 
   const hasLocationUsers = roomUsers
     .filter((user) => !!user.start_location)
@@ -18,7 +20,7 @@ export const useGetHalfway = (roomUsers: RoomUser[]) => {
     if (result && numberOfStartLocation >= 2) {
       setHalfwayPoint(result);
     }
-  }, [result?.lat, result?.lng]);
+  }, [result.lat, result.lng]);
 
   return { halfwayPoint };
 };

--- a/src/types/place.types.ts
+++ b/src/types/place.types.ts
@@ -19,3 +19,8 @@ export type UserLocationData = {
   lat: string;
   lng: string;
 };
+
+export type Halfway = {
+  lat: number | null;
+  lng: number | null;
+};

--- a/src/utils/place/calcCenterPoint.ts
+++ b/src/utils/place/calcCenterPoint.ts
@@ -3,7 +3,7 @@ export default function calcCenterPoint(points: { location: { lat: number; lng: 
   let y = 0;
   let s = 0;
 
-  if (points === undefined) return;
+  if (points === undefined) return { lat: null, lng: null };
 
   if (points.length === 1) {
     const lat = points[0].location.lat;
@@ -23,13 +23,17 @@ export default function calcCenterPoint(points: { location: { lat: number; lng: 
     x +=
       (points[i].location.lat + points[j].location.lat) *
       (points[i].location.lat * points[j].location.lng - points[j].location.lat * points[i].location.lng);
+
     y +=
       (points[i].location.lng + points[j].location.lng) *
       (points[i].location.lat * points[j].location.lng - points[j].location.lat * points[i].location.lng);
+
     s += points[i].location.lat * points[j].location.lng - points[j].location.lat * points[i].location.lng;
   }
+
   s /= 2;
   x = x / (6 * s);
   y = y / (6 * s);
+
   return { lat: x, lng: y };
 }

--- a/src/utils/place/convexHull.ts
+++ b/src/utils/place/convexHull.ts
@@ -39,5 +39,6 @@ export default function convexHull(points: { location: { lat: number; lng: numbe
 
   upperHull.pop();
   lowerHull.pop();
+
   return upperHull.concat(lowerHull);
 }


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #75 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] util 함수 반환 타입 맞추기
- [x] 변경된 타입 수정 및 적용하기

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
util 함수 반환 타입 맞추기
변경된 타입 수정 및 적용하기
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
초기에 calcCenterPoint 함수에서 반환된 result의 lat, lng 값을 의존성 배열의 변수로 넣어 사용하고 있습니다.

calcCenterPoint에서 계산할 매개변수가 없을 경우 빈 return으로 함수를 종료 하여 result의 타입이 {...} | undefined로 추론됩니다.

의존성 배열에서 [ result?.lat, result?.lng ] 옵셔널체이닝으로 사용되고 있습니다.
=>
 calcCenterPoint의 빈 return 문을 {lat: null, lng: null} 로 변경하여 반환 타입을 맞추고 옵셔널 체이닝을 사용안합니다.
```
## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
