### PR TITLE
[Feature/profile] 유저 프로필 사진 수정 사항 즉각 반영 및 수정 취소 클릭 시 기존 프로필 정보 복원

### DIFF
--- a/src/components/my-owl/profile/editable/UserInfo.tsx
+++ b/src/components/my-owl/profile/editable/UserInfo.tsx
@@ -3,7 +3,7 @@
 import { ChangeEvent, useState } from 'react';
 
 import { ImageUploadModal } from './modal/Modal';
-import { updateUserName } from '@/api/supabaseCSR/supabase';
+import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
 
 import styles from './UserInfo.module.css';
 import Image from 'next/image';
@@ -17,6 +17,7 @@ export interface UserInfoProps {
 const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
   const [editMode, setEditMode] = useState(false);
   const [userName, setUserName] = useState(name);
+  const [userProfileURL, setUserProfileURL] = useState(profileURL);
   const [toggleModal, setToggleModal] = useState(false);
 
   const handleChangeUserInfo = (event: ChangeEvent<HTMLInputElement>) => {
@@ -26,6 +27,7 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
 
   const handleEditExit = () => {
     setUserName(name);
+    setUserProfileURL(profileURL);
     setEditMode(false);
   };
 
@@ -33,8 +35,11 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
     setEditMode((prev) => !prev);
   };
 
-  const handleNameEditDone = () => {
+  const handleEditDone = () => {
     updateUserName(userId, userName);
+    if (userProfileURL !== null) {
+      changeUserProfile({ userId, profile_url: userProfileURL });
+    }
     setEditMode(false);
   };
 
@@ -44,7 +49,7 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
 
   return (
     <div className={styles.user_container}>
-      <div className={styles.profile_image} style={{ backgroundImage: `url(${profileURL})` }}>
+      <div className={styles.profile_image} style={{ backgroundImage: `url(${userProfileURL})` }}>
         {editMode ? (
           <Image
             className={styles.edit}
@@ -63,7 +68,7 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
             <button className={styles.button} onClick={handleEditExit}>
               취소
             </button>
-            <button className={styles.button} onClick={handleNameEditDone}>
+            <button className={styles.button} onClick={handleEditDone}>
               완료
             </button>
           </>
@@ -73,7 +78,7 @@ const UserInfo = ({ userId, name, profileURL }: UserInfoProps) => {
           </button>
         )}
       </div>
-      {toggleModal && <ImageUploadModal handleToggleModal={handleToggleModal} />}
+      {toggleModal && <ImageUploadModal handleToggleModal={handleToggleModal} setUserProfileURL={setUserProfileURL} />}
     </div>
   );
 };

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, MouseEvent, useState } from 'react';
+import { ChangeEvent, Dispatch, MouseEvent, SetStateAction, useState } from 'react';
 import { changeUserProfile, uploadImage } from '@/api/supabaseCSR/supabase';
 import { byteCalculator } from '@/utils/my-owl/profile/modal/byteCalculator';
 import { getUserId } from '@/utils/my-owl/getUserId';
@@ -7,13 +7,18 @@ import styles from './Modal.module.css';
 
 const MAX_FILE_SIZE_BYTE = 2097152; //2MB
 
-export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () => void }) => {
+export const ImageUploadModal = ({
+  handleToggleModal,
+  setUserProfileURL
+}: {
+  handleToggleModal: () => void;
+  setUserProfileURL: Dispatch<SetStateAction<string | null>>;
+}) => {
   const [fileSizeExceed, setFileSizeExceed] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [url, setUrl] = useState('');
   const [isValidUrl, setIsValidUrl] = useState(true);
 
-  //파일 용량 제한 로직
   const handleFileMaxSize = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
     if (files !== null) {
@@ -35,15 +40,13 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
     }
   };
 
-  //유저 이미지 변경 전체 핸들러
   const handleUploadImage = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (file) {
       const profile_url = await uploadImage(file, setFile);
-      const userId = await getUserId();
       handleToggleModal();
-      if (userId && profile_url) {
-        await changeUserProfile({ userId, profile_url });
+      if (profile_url) {
+        setUserProfileURL(profile_url);
       } else {
         alert(`문제가 발생하였습니다`);
       }
@@ -77,10 +80,7 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
       alert('유효하지 않은 URL 형식입니다. URL 파일의 형식을 확인해주세요.');
       setUrl('');
     }
-    const userId = await getUserId();
-    if (userId) changeUserProfile({ userId, profile_url: url });
-    else alert('유저의 신원 확인이 불가능합니다.');
-    setUrl('');
+    setUserProfileURL(url);
     handleToggleModal();
   };
 

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent, Dispatch, MouseEvent, SetStateAction, useState } from 'react';
-import { changeUserProfile, uploadImage } from '@/api/supabaseCSR/supabase';
+import { uploadImage } from '@/api/supabaseCSR/supabase';
 import { byteCalculator } from '@/utils/my-owl/profile/modal/byteCalculator';
-import { getUserId } from '@/utils/my-owl/getUserId';
 
 import styles from './Modal.module.css';
 

--- a/src/components/my-owl/profile/editable/modal/Modal.tsx
+++ b/src/components/my-owl/profile/editable/modal/Modal.tsx
@@ -13,26 +13,6 @@ export const ImageUploadModal = ({ handleToggleModal }: { handleToggleModal: () 
   const [url, setUrl] = useState('');
   const [isValidUrl, setIsValidUrl] = useState(true);
 
-  //util
-  const byteCalculater = (byte: number) => {
-    const KB = byte / 1024;
-    const MB = KB / 1024;
-    const GB = MB / 1024;
-    const TB = GB / 1024;
-
-    if (TB >= 1) {
-      return `${TB.toFixed(2)} TB`;
-    } else if (GB >= 1) {
-      return `${GB.toFixed(2)} GB`;
-    } else if (MB >= 1) {
-      return `${MB.toFixed(2)} MB`;
-    } else if (KB >= 1) {
-      return `${KB.toFixed(2)} KB`;
-    } else {
-      return `${byte} bytes`;
-    }
-  };
-
   //파일 용량 제한 로직
   const handleFileMaxSize = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #77 
closed #56 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 유저 프로필 수정 사항 즉각 반영
- [ ] 유저 프로필 수정 취소 클릭 시 기존 프로필 정보 복원

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
유저가 프로필 사진을 올리면 프로필 상 화면에 보여줍니다. 
취소 버튼을 누르면 기존 프로필 이미지로 복원됩니다.
* 현재 상태 관리가 지역으로 되어있어서 코드 보기에 정신 없습니다! 
merge이후 상태 관리 로직 변경해서 새로 PR올릴 예정입니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
프로필 수정 사항 반영을 어떻게 할 지 많은 고민을 했는데,
state를 사용하여 관리함으로써 생각보다 쉽게 해당 문제를 해결하였습니다.
추가적으로 유저가 사진을 업로드 하는 경우, 완료를 눌렀을 때 supabase storage에 업로드 되도록 하면 자원 낭비를 줄일 수 있어 더욱 좋을 것 같습니다. 
로직을 구현하다 보니, 마이페이지와 관련된 것들을 zustand로 전역 상태관리 해야할 것 같아 한 번 머지한 이후 상태 관리 전환하겠습니다!
```
## 📸 스크린샷(선택)
![화면 기록 2024-04-08 오후 2 57 06 (1)](https://github.com/where-we-meet/owl/assets/69431340/162f84fa-bbca-45e4-9918-e8b40dc4bd6a)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
