### PR TITLE
[Feature/db] my-owl/Meeting.tsx내부의 로직을 변경

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -63,21 +63,30 @@ export const getUsersData = async (id: string) => {
   return data;
 };
 
-export const getMyProfile = async (id: string) => {
+export const getMyParticipatingRoomsData = async (id: string[]) => {
   const { data, error } = await supabase
     .from('rooms')
-    .select(`id,
+    .select(
+      `
+      id,
       name,
+      confirmed_date,
       created_at,
       location,
       verified,
-      users(*)
-      `
+      userdata_room(
+        user_id,
+        users!inner(
+          profile_url
+        )
+      )
+    `
     )
-    .eq('id', id)
+    .in('id', id);
+
   if (error) throw error;
-  return data
-}
+  return data;
+};
 
 //유저 프로필 사진 업데이트 로직
 export const changeUserProfile = async ({ userId, profile_url }: { userId: string; profile_url: string }) => {

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -63,6 +63,22 @@ export const getUsersData = async (id: string) => {
   return data;
 };
 
+export const getMyProfile = async (id: string) => {
+  const { data, error } = await supabase
+    .from('rooms')
+    .select(`id,
+      name,
+      created_at,
+      location,
+      verified,
+      users(name, profile_url)
+      `
+    )
+    .eq('id', id)
+  if (error) throw error;
+  return data
+}
+
 //유저 프로필 사진 업데이트 로직
 export const changeUserProfile = async ({ userId, profile_url }: { userId: string; profile_url: string }) => {
   const { data, error } = await supabase.from('users').update({ profile_url }).eq('id', userId);

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -71,7 +71,7 @@ export const getMyProfile = async (id: string) => {
       created_at,
       location,
       verified,
-      users(name, profile_url)
+      users(*)
       `
     )
     .eq('id', id)

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -13,15 +13,6 @@ export const getCurrentUserData = async () => {
   return data;
 };
 
-// supabase에서 roomId를 통해 room에 관련된 모든 Data 반환
-export const getRoomData = async (id: string) => {
-  const { data, error } = await supabase
-    .from('rooms')
-    .select('id, created_at, created_by, location, name, verified')
-    .eq('id', id);
-  if (error) throw error;
-  return data;
-};
 
 // supabase에서 roomId를 통해 해당 room 일정과 관련된 모든 Data 반환
 export const getUserSchedule = async (id: string) => {
@@ -57,11 +48,7 @@ export const getRoomUsersData = async (id: string) => {
   return data;
 };
 
-export const getUsersData = async (id: string) => {
-  const { data, error } = await supabase.from('users').select('*').eq('id', id);
-  if (error) throw error;
-  return data;
-};
+
 
 export const getMyParticipatingRoomsData = async (id: string[]) => {
   const { data, error } = await supabase
@@ -119,12 +106,6 @@ export const updateUserName = async (userId: string, newName: string) => {
   if (error) throw error;
 };
 
-// room에 참여하고 있는 유저의 Id Data 반환
-export const getRoomParticipantsId = async (roomId: string) => {
-  const { data, error } = await supabase.from('userdata_room').select('user_id').eq('room_id', roomId);
-  if (error) throw error;
-  return data;
-};
 
 export const getUserMeetingsId = async (userId: string) => {
   if (userId !== null) {

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { getRoomData, getUsersData, getRoomParticipantsId, getUserMeetingsId } from '@/api/supabaseCSR/supabase';
+import { getRoomData, getUsersData, getRoomParticipantsId, getUserMeetingsId, getMyProfile } from '@/api/supabaseCSR/supabase';
 import { getUserId } from '@/utils/my-owl/getUserId';
 import { sortMeetingInfo } from '@/utils/my-owl/meeting/sortMeetingInfo';
 
@@ -26,6 +26,8 @@ export interface MeetingInfo {
 export const Meeting = () => {
   const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
   const router = useRouter();
+
+
   useEffect(() => {
     const fetchMeetingInfo = async () => {
       const userId = await getUserId();

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -3,7 +3,13 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { getRoomData, getUsersData, getRoomParticipantsId, getUserMeetingsId, getMyProfile } from '@/api/supabaseCSR/supabase';
+import {
+  getRoomData,
+  getUsersData,
+  getRoomParticipantsId,
+  getUserMeetingsId,
+  getMyParticipatingRoomsData
+} from '@/api/supabaseCSR/supabase';
 import { getUserId } from '@/utils/my-owl/getUserId';
 import { sortMeetingInfo } from '@/utils/my-owl/meeting/sortMeetingInfo';
 
@@ -27,33 +33,14 @@ export const Meeting = () => {
   const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
   const router = useRouter();
 
-
   useEffect(() => {
     const fetchMeetingInfo = async () => {
       const userId = await getUserId();
-      const meetingIds = await getUserMeetingsId(userId);
-      const meetingInfoPromises = meetingIds.map(async (meetingId: { room_id: string }) => {
-        const roomId = meetingId.room_id;
-        const roomInfo = await getRoomData(roomId);
-        const participantsIds = await getRoomParticipantsId(roomId);
-        const participantsInfoPromises = participantsIds.map(async (participantId: { user_id: string }) => {
-          const userInfo = await getUsersData(participantId.user_id);
-          return userInfo[0];
-        });
-        const participantsInfo = await Promise.all(participantsInfoPromises);
-        return {
-          id: roomId,
-          name: roomInfo[0].name,
-          location: roomInfo[0].location,
-          participants: participantsInfo,
-          created_at: roomInfo[0].created_at,
-          verified: roomInfo[0].verified
-        };
-      });
-      const fetchedMeetingInfo = await Promise.all(meetingInfoPromises);
+      const roomData = await getUserMeetingsId(userId);
+      const roomIds = roomData.map((item) => item.room_id);
+      const fetchedData = await getMyParticipatingRoomsData(roomIds);
+      console.log('데이터의 상태', fetchedData);
 
-      const sortedMeetingInfo = sortMeetingInfo(fetchedMeetingInfo as MeetingInfo[]);
-      setMeetingInfo(sortedMeetingInfo);
     };
 
     fetchMeetingInfo();

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -3,13 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import {
-  getRoomData,
-  getUsersData,
-  getRoomParticipantsId,
-  getUserMeetingsId,
-  getMyParticipatingRoomsData
-} from '@/api/supabaseCSR/supabase';
+import { getUserMeetingsId, getMyParticipatingRoomsData } from '@/api/supabaseCSR/supabase';
 import { getUserId } from '@/utils/my-owl/getUserId';
 import { sortMeetingInfo } from '@/utils/my-owl/meeting/sortMeetingInfo';
 
@@ -44,7 +38,6 @@ export const Meeting = () => {
       const fetchedData = await getMyParticipatingRoomsData(roomIds);
       const sortedData = sortMeetingInfo(fetchedData);
       setMeetingInfo(sortedData);
-      console.log('데이터의 상태', sortedData);
     };
 
     fetchMeetingInfo();

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -15,19 +15,22 @@ import { sortMeetingInfo } from '@/utils/my-owl/meeting/sortMeetingInfo';
 
 import styles from './Meeting.module.css';
 
-export interface UserInfo {
-  name: string;
-  profile_url: string;
-}
+export type UserInfo = {
+  user_id: string;
+  users: {
+    profile_url: string | null;
+  } | null;
+};
 
-export interface MeetingInfo {
-  id: string | null;
+export type MeetingInfo = {
+  id: string;
   name: string | null;
+  confirmed_date: string | null;
+  created_at: string;
   location: string | null;
-  participants: UserInfo[];
-  created_at: string | null;
-  verified: boolean;
-}
+  verified: boolean | null;
+  userdata_room: UserInfo[];
+};
 
 export const Meeting = () => {
   const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
@@ -40,7 +43,7 @@ export const Meeting = () => {
       const roomIds = roomData.map((item) => item.room_id);
       const fetchedData = await getMyParticipatingRoomsData(roomIds);
       console.log('데이터의 상태', fetchedData);
-
+      setMeetingInfo(fetchedData);
     };
 
     fetchMeetingInfo();

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -42,13 +42,13 @@ export const Meeting = () => {
       const roomData = await getUserMeetingsId(userId);
       const roomIds = roomData.map((item) => item.room_id);
       const fetchedData = await getMyParticipatingRoomsData(roomIds);
-      console.log('데이터의 상태', fetchedData);
-      setMeetingInfo(fetchedData);
+      const sortedData = sortMeetingInfo(fetchedData);
+      setMeetingInfo(sortedData);
+      console.log('데이터의 상태', sortedData);
     };
 
     fetchMeetingInfo();
   }, []);
-
   const handleClickRoom = (roomId: string | null) => {
     router.push(`/room/${roomId}`);
   };
@@ -59,20 +59,20 @@ export const Meeting = () => {
           <div className={styles.room_box}>
             <div className={styles.room_box_left}>
               <h3>{meeting.name}</h3>
-              <p>날짜</p>
+              <p>날짜 : {meeting.confirmed_date}</p>
               <p>위치 : {meeting.location}</p>
             </div>
             <div className={styles.room_box_right}>
               <div className={styles.participants_container}>
-                {meeting.participants.map((participant, index) => (
+                {meeting.userdata_room.map((participant, index) => (
                   <div
                     className={styles.participant_profile}
-                    style={{ backgroundImage: `url(${participant.profile_url})` }}
+                    style={{ backgroundImage: `url(${participant.users?.profile_url})` }}
                     key={index}
                   />
                 ))}
               </div>
-              <p>{meeting.participants.length}명 참여중</p>
+              <p>{meeting.userdata_room.length}명 참여중</p>
             </div>
           </div>
         </div>

--- a/src/components/room/meeting/calender/calculateOfMonth.ts
+++ b/src/components/room/meeting/calender/calculateOfMonth.ts
@@ -1,0 +1,24 @@
+import { startOfMonth, endOfMonth, startOfWeek, endOfWeek, addDays } from 'date-fns';
+
+const calculateOfMonth = (nowDate: Date) => {
+  const monthStart = startOfMonth(nowDate);
+  const monthEnd = endOfMonth(monthStart);
+  const startDay = startOfWeek(monthStart);
+  const endDay = endOfWeek(monthEnd);
+  const entireOfMonth = [];
+
+  let startWeek = startDay;
+  let entireOfWeek = [];
+
+  while (startWeek <= endDay) {
+    for (let i = 0; i < 7; i++) {
+      entireOfWeek.push(startWeek);
+      startWeek = addDays(startWeek, 1);
+    }
+    entireOfMonth.push(entireOfWeek);
+    entireOfWeek = [];
+  }
+  return entireOfMonth;
+};
+
+export default calculateOfMonth;

--- a/src/components/room/meeting/calender/checkSelectedDates.ts
+++ b/src/components/room/meeting/calender/checkSelectedDates.ts
@@ -1,0 +1,5 @@
+const checkSelectedDates = (selectedDate: Date[]) => {
+  return selectedDate.length > 0; // 선택된 날짜가 있는지 여부를 확인하여 반환합니다.
+};
+
+export default checkSelectedDates;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -1,247 +1,263 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[];
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   public: {
     Tables: {
       room_schedule: {
         Row: {
-          created_at: string;
-          created_by: string | null;
-          end_date: string | null;
-          id: string;
-          room_id: string | null;
-          start_date: string | null;
-        };
+          created_at: string
+          created_by: string | null
+          end_date: string | null
+          id: string
+          room_id: string | null
+          start_date: string | null
+        }
         Insert: {
-          created_at?: string;
-          created_by?: string | null;
-          end_date?: string | null;
-          id?: string;
-          room_id?: string | null;
-          start_date?: string | null;
-        };
+          created_at?: string
+          created_by?: string | null
+          end_date?: string | null
+          id?: string
+          room_id?: string | null
+          start_date?: string | null
+        }
         Update: {
-          created_at?: string;
-          created_by?: string | null;
-          end_date?: string | null;
-          id?: string;
-          room_id?: string | null;
-          start_date?: string | null;
-        };
+          created_at?: string
+          created_by?: string | null
+          end_date?: string | null
+          id?: string
+          room_id?: string | null
+          start_date?: string | null
+        }
         Relationships: [
           {
-            foreignKeyName: 'public_room_schedule_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
+            foreignKeyName: "public_room_schedule_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'public_room_schedule_room_id_fkey';
-            columns: ['room_id'];
-            isOneToOne: false;
-            referencedRelation: 'rooms';
-            referencedColumns: ['id'];
-          }
-        ];
-      };
+            foreignKeyName: "public_room_schedule_room_id_fkey"
+            columns: ["room_id"]
+            isOneToOne: false
+            referencedRelation: "rooms"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       rooms: {
         Row: {
-          confirmed_date: string | null;
-          created_at: string;
-          created_by: string | null;
-          id: string;
-          lat: string | null;
-          lng: string | null;
-          location: string | null;
-          name: string | null;
-          verified: boolean | null;
-        };
+          confirmed_date: string | null
+          created_at: string
+          created_by: string | null
+          id: string
+          lat: string | null
+          lng: string | null
+          location: string | null
+          name: string | null
+          verified: boolean
+        }
         Insert: {
-          confirmed_date?: string | null;
-          created_at?: string;
-          created_by?: string | null;
-          id?: string;
-          lat?: string | null;
-          lng?: string | null;
-          location?: string | null;
-          name?: string | null;
-          verified?: boolean | null;
-        };
+          confirmed_date?: string | null
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          lat?: string | null
+          lng?: string | null
+          location?: string | null
+          name?: string | null
+          verified?: boolean
+        }
         Update: {
-          confirmed_date?: string | null;
-          created_at?: string;
-          created_by?: string | null;
-          id?: string;
-          lat?: string | null;
-          lng?: string | null;
-          location?: string | null;
-          name?: string | null;
-          verified?: boolean | null;
-        };
+          confirmed_date?: string | null
+          created_at?: string
+          created_by?: string | null
+          id?: string
+          lat?: string | null
+          lng?: string | null
+          location?: string | null
+          name?: string | null
+          verified?: boolean
+        }
         Relationships: [
           {
-            foreignKeyName: 'public_rooms_created_by_fkey';
-            columns: ['created_by'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          }
-        ];
-      };
+            foreignKeyName: "public_rooms_created_by_fkey"
+            columns: ["created_by"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       userdata_room: {
         Row: {
-          created_at: string;
-          id: string;
-          is_admin: boolean;
-          lat: string | null;
-          lng: string | null;
-          room_id: string;
-          start_location: string | null;
-          user_id: string;
-        };
+          created_at: string
+          id: string
+          is_admin: boolean
+          lat: string | null
+          lng: string | null
+          room_id: string
+          start_location: string | null
+          user_id: string
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          is_admin?: boolean;
-          lat?: string | null;
-          lng?: string | null;
-          room_id: string;
-          start_location?: string | null;
-          user_id: string;
-        };
+          created_at?: string
+          id?: string
+          is_admin?: boolean
+          lat?: string | null
+          lng?: string | null
+          room_id: string
+          start_location?: string | null
+          user_id: string
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          is_admin?: boolean;
-          lat?: string | null;
-          lng?: string | null;
-          room_id?: string;
-          start_location?: string | null;
-          user_id?: string;
-        };
+          created_at?: string
+          id?: string
+          is_admin?: boolean
+          lat?: string | null
+          lng?: string | null
+          room_id?: string
+          start_location?: string | null
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: 'public_userdata_room_room_id_fkey';
-            columns: ['room_id'];
-            isOneToOne: false;
-            referencedRelation: 'rooms';
-            referencedColumns: ['id'];
+            foreignKeyName: "public_userdata_room_room_id_fkey"
+            columns: ["room_id"]
+            isOneToOne: false
+            referencedRelation: "rooms"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: 'public_userdata_room_user_id_fkey';
-            columns: ['user_id'];
-            isOneToOne: false;
-            referencedRelation: 'users';
-            referencedColumns: ['id'];
-          }
-        ];
-      };
+            foreignKeyName: "public_userdata_room_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       users: {
         Row: {
-          created_at: string;
-          id: string;
-          name: string;
-          profile_url: string | null;
-        };
+          created_at: string
+          id: string
+          name: string
+          profile_url: string | null
+        }
         Insert: {
-          created_at?: string;
-          id?: string;
-          name: string;
-          profile_url?: string | null;
-        };
+          created_at?: string
+          id?: string
+          name: string
+          profile_url?: string | null
+        }
         Update: {
-          created_at?: string;
-          id?: string;
-          name?: string;
-          profile_url?: string | null;
-        };
-        Relationships: [];
-      };
-    };
+          created_at?: string
+          id?: string
+          name?: string
+          profile_url?: string | null
+        }
+        Relationships: []
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type PublicSchema = Database[Extract<keyof Database, 'public'>];
+type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views']) | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-        Database[PublicTableNameOrOptions['schema']]['Views'])
-    : never = never
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions['schema']]['Tables'] &
-      Database[PublicTableNameOrOptions['schema']]['Views'])[TableName] extends {
-      Row: infer R;
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
     }
     ? R
     : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema['Tables'] & PublicSchema['Views'])
-  ? (PublicSchema['Tables'] & PublicSchema['Views'])[PublicTableNameOrOptions] extends {
-      Row: infer R;
-    }
-    ? R
+  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
+        PublicSchema["Views"])
+    ? (PublicSchema["Tables"] &
+        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never;
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
-    : never = never
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Insert: infer I;
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
     }
     ? I
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-      Insert: infer I;
-    }
-    ? I
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never;
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends keyof PublicSchema['Tables'] | { schema: keyof Database },
+  PublicTableNameOrOptions extends
+    | keyof PublicSchema["Tables"]
+    | { schema: keyof Database },
   TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions['schema']]['Tables']
-    : never = never
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never,
 > = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions['schema']]['Tables'][TableName] extends {
-      Update: infer U;
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
     }
     ? U
     : never
-  : PublicTableNameOrOptions extends keyof PublicSchema['Tables']
-  ? PublicSchema['Tables'][PublicTableNameOrOptions] extends {
-      Update: infer U;
-    }
-    ? U
+  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
+    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never;
 
 export type Enums<
-  PublicEnumNameOrOptions extends keyof PublicSchema['Enums'] | { schema: keyof Database },
+  PublicEnumNameOrOptions extends
+    | keyof PublicSchema["Enums"]
+    | { schema: keyof Database },
   EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions['schema']]['Enums']
-    : never = never
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never,
 > = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema['Enums']
-  ? PublicSchema['Enums'][PublicEnumNameOrOptions]
-  : never;
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
+    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#85 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] my-owl/Meeting.tsx 내부로직을 수정
- [ ] useEffect로 호출중인 supabase 로직을 커스텀 훅으로 분리

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
1. 기존에 존재하는 supabase의 쿼리 로직을 테이블 조인을 통해 하나로 합쳤습니다.
2. DB에서 필요한 정보들을 압축하고 클라이언트에서 실행하는 로직을 줄였습니다.
3. 실제 와이어프레임에 존재하는 확정일자(confirmed_data)를 사용하였습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. 로직을 합치는 과정에서 테이블 조인의 문제가 발생했습니다.
- 쿼리를 두 번 하는 것으로 해당 문제를 해결 할 수 있었습니다.
2. DB 클라이언트에서 실행하는 로직들을 간소화 시킬 때 타입문제가 발생하였습니다.
-  nullish value가 존재하기떄문에 옵셔널체이닝을 사용한 부분이 존재합니다.
3. 실제 와이어 프레임에 존재하는 데이터를 사용하지 않았기 때문에 추가하였습니다.
- 데이터를 입력식으로 반영했을 뿐 월/일 방식으로 변환이 필요한 로직이 존재합니다.
```
## 📸 스크린샷(선택)
![image](https://github.com/where-we-meet/owl/assets/109938441/90bd1dff-d470-4def-8963-8e4d0aca2022)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

해당 로직은 useEffect를 포함한 커스텀 훅으로 분리가 가능 할 것 같습니다.
또한, supabase 내부에서 존재하는 컬럼의 타입에서 nullish 밸류를 삭제하면 더 견고한 타입을 지정 할 수 있을것으로 예상됩니다.
## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
