### PR TITLE
[Feat] 캘린더의 데이터를 realtime으로 적용

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -13,13 +13,9 @@ export const getCurrentUserData = async () => {
   return data;
 };
 
-
 // supabase에서 roomId를 통해 해당 room 일정과 관련된 모든 Data 반환
 export const getUserSchedule = async (id: string) => {
-  const { data, error } = await supabase
-    .from('room_schedule')
-    .select('room_id, start_date, end_date, created_by')
-    .eq('room_id', id);
+  const { data, error } = await supabase.from('room_schedule').select('*').eq('room_id', id);
   if (error) throw error;
   return data;
 };
@@ -47,8 +43,6 @@ export const getRoomUsersData = async (id: string) => {
   if (error) throw error;
   return data;
 };
-
-
 
 export const getMyParticipatingRoomsData = async (id: string[]) => {
   const { data, error } = await supabase
@@ -105,7 +99,6 @@ export const updateUserName = async (userId: string, newName: string) => {
   const { data, error } = await supabase.from('users').update({ name: newName }).eq('id', userId);
   if (error) throw error;
 };
-
 
 export const getUserMeetingsId = async (userId: string) => {
   if (userId !== null) {

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -41,10 +41,13 @@ export const Meeting = () => {
     };
 
     fetchMeetingInfo();
+
   }, []);
+
   const handleClickRoom = (roomId: string | null) => {
     router.push(`/room/${roomId}`);
   };
+  
   return (
     <div className={styles.meeting_container}>
       {meetingInfo.map((meeting, index) => (

--- a/src/hooks/useGetCalendar.ts
+++ b/src/hooks/useGetCalendar.ts
@@ -30,7 +30,6 @@ export const useGetCalendar = (id: string) => {
               schedule.id === updatedSchedule.id ? { ...schedule, start_date: updatedSchedule.start_date } : schedule
             )
           );
-          console.log('dsdsdasd', payload);
         }
       )
       .subscribe();


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #53
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 이걸 계속 복사해서 사용해주세요!

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
1. 기존에 추가되던 캘린더의 데이터를 realtime으로 적용합니다
2. 데이터를 fetch해오는 로직과 적용로직을 별도의 커스텀 훅으로 분리합니다
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. payload로 적용하는 부분의 로직을 단순 추가로 하여 수정이 아닌 추가만 되는 현상
- 캘린더 값의 변경된 id를 추적하여 적용시켰습니다.

3. 데이터를 realtime으로 적용하는 과정에서 초기 접속시 실시간 반영이 되지 않았던 문제가 있습니다.
- 의존성 배열에 start_date를 가지고 있는 userSchedules를 포함하여 실시간 반영이 되도록 적용하였습니다.
```
## 📸 스크린샷(선택)
![GIF 2024-04-09 오후 9-29-52](https://github.com/where-we-meet/owl/assets/109938441/1f45c45f-5671-479c-8690-75180f7471dd)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
