### PR TITLE
[feat] 기존 mypage의 Meeting 컴포넌트를 사이드 바 하위 경로로 위치를 변경.

### DIFF
--- a/src/app/my-owl/page.tsx
+++ b/src/app/my-owl/page.tsx
@@ -1,11 +1,9 @@
-import { Meeting } from '@/components/my-owl/meeting/Meeting';
 import Profile from '@/components/my-owl/profile/Profile';
 
 export default function MyOwl() {
   return (
     <main style={{ display: 'flex' }}>
       <Profile />
-      <Meeting />
     </main>
   );
 }

--- a/src/components/auth/MeetingButton.tsx
+++ b/src/components/auth/MeetingButton.tsx
@@ -13,10 +13,10 @@ export const MeetingButton = () => {
 
   return (
     <div>
-      <button className='border-transparent' onClick={(e) => onChangeSideBarStatus(e)}>
+      <button className="border-transparent" onClick={(e) => onChangeSideBarStatus(e)}>
         <GiHamburgerMenu />
       </button>
-      {showSideBar ? <Meeting /> : <></>}
+      {showSideBar ? <Meeting /> : null}
     </div>
   );
 };

--- a/src/components/auth/MeetingButton.tsx
+++ b/src/components/auth/MeetingButton.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { MouseEvent, useState } from 'react';
+import { Meeting } from '../my-owl/meeting/Meeting';
+import { GiHamburgerMenu } from 'react-icons/gi';
+
+export const MeetingButton = () => {
+  const [showSideBar, setShowSideBar] = useState(false);
+
+  const onChangeSideBarStatus = (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setShowSideBar(!showSideBar);
+  };
+
+  return (
+    <div>
+      <button className='border-transparent' onClick={(e) => onChangeSideBarStatus(e)}>
+        <GiHamburgerMenu />
+      </button>
+      {showSideBar ? <Meeting /> : <></>}
+    </div>
+  );
+};

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -13,11 +13,7 @@ const Header = async () => {
 
   return (
     <header className={styles.header}>
-      {user ? (
-          <MeetingButton />
-      ) : (
-        <></>
-      )}
+      {user ? <MeetingButton /> : null}
       <Link href="/">owl-link</Link>
       <div className={styles.menu}>
         {user ? (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { createClient } from '@/utils/supabase/server';
 import Logout from '../auth/LogoutButton';
 import styles from './Header.module.css';
 import Link from 'next/link';
+import { MeetingButton } from '../auth/MeetingButton';
 
 const Header = async () => {
   const supabase = await createClient();
@@ -12,6 +13,11 @@ const Header = async () => {
 
   return (
     <header className={styles.header}>
+      {user ? (
+          <MeetingButton />
+      ) : (
+        <></>
+      )}
       <Link href="/">owl-link</Link>
       <div className={styles.menu}>
         {user ? (


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#102 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] Meeting 컴포넌트를 외부로 분리
- [ ] 상호작용 시 사이드에서 출력되는 디자인 추가
## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
기존 my-owl 내부의 Meeting
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. react-icon을 사용하는 방법에 미숙해서 image 파일을 직접 삽입하려고함
-  팀원들의 도움으로 해결
```
## 📸 스크린샷(선택)

![burger_sidebar](https://github.com/where-we-meet/owl/assets/109938441/f5bc8bf0-171f-4f7b-ae5b-5e4961ceb525)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
