### PR TITLE
[feat/header profile] 유저 프로필 설정 UI/UX 를 모달로 수정

### DIFF
--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -3,9 +3,14 @@
 import { Button, Modal, ModalContent, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
 import { PiUserSquareDuotone } from 'react-icons/pi';
 
-const UserProfile = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+export type UserInfoProps = {
+  userId: string;
+  name: string;
+  profileURL: string | null;
+} | null;
 
+const UserProfile = ({ userInfo, authSNS }: { userInfo: UserInfoProps; authSNS: Array<string> }) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const handleOpen = () => {
     onOpen();
   };

--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -3,6 +3,10 @@
 import { Button, Image, Modal, ModalContent, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
 import { PiUserSquareDuotone } from 'react-icons/pi';
 import { GrCaretNext } from 'react-icons/gr';
+import { IoClose, IoChevronBack } from 'react-icons/io5';
+import { ChangeEvent, useState } from 'react';
+import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
+import { ImageUploadModal } from '../my-owl/profile/editable/modal/Modal';
 
 export type UserInfoProps = {
   userId: string;
@@ -12,8 +16,55 @@ export type UserInfoProps = {
 
 const UserProfile = ({ userInfo, authSNS }: { userInfo: UserInfoProps; authSNS: Array<string> }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const [editMode, setEditMode] = useState(false);
+  const MAX_NAME_LENGTH = 16;
+
+  /*
+   * edit mode에서 쓰는 state
+   */
+  const [userName, setUserName] = useState(userInfo.name);
+  const [userProfileURL, setUserProfileURL] = useState(userInfo.profileURL);
+  const [toggleModal, setToggleModal] = useState(false);
+  const handleToggleModal = () => {
+    setToggleModal((prev) => !prev);
+  };
+  const handleChangeUserName = (event: ChangeEvent<HTMLInputElement>) => {
+    const name = event.target.value;
+    setUserName(name);
+  };
+
+  const handleEditDone = () => {
+    if (userName.length < 1) {
+      alert('닉네임은 최소 1글자 이상으로 지어주세요.');
+    } else if (userName.length > 16) {
+      alert('닉네임은 최대 16글자 이하로 지어주세요.');
+    } else {
+      updateUserName(userInfo.userId, userName);
+      if (userProfileURL !== null) {
+        changeUserProfile({ userId: userInfo.userId, profile_url: userProfileURL });
+      }
+      setEditMode(false);
+    }
+  };
+  ///////////////////
+
   const handleOpen = () => {
     onOpen();
+  };
+  const handleClose = () => {
+    setUserName(userInfo.name);
+    setUserProfileURL(userInfo.profileURL);
+    setEditMode(false);
+    onClose();
+  };
+  const handleEditMode = () => {
+    setEditMode((prev) => !prev);
+  };
+
+  const handleEditExit = () => {
+    setUserName(userInfo.name);
+    setUserProfileURL(userInfo.profileURL);
+    setEditMode(false);
   };
   return (
     <>
@@ -22,35 +73,72 @@ const UserProfile = ({ userInfo, authSNS }: { userInfo: UserInfoProps; authSNS: 
           <PiUserSquareDuotone />
         </Button>
       </div>
-      <Modal backdrop="blur" isOpen={isOpen} onClose={onClose}>
+      <Modal backdrop="blur" isOpen={isOpen} onClose={handleClose} hideCloseButton>
         <ModalContent>
-          <>
-            <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
-            <ModalBody>
-              <Image width={100} alt="profile_image" src={`${userInfo.profileURL}`} />
-              <div>
-                <p>닉네임</p>
+          {editMode ? (
+            <>
+              <Button isIconOnly onPress={handleEditExit}>
+                <IoChevronBack />
+              </Button>
+              <ModalHeader className="flex flex-col gap-1">프로필 수정</ModalHeader>
+              <ModalBody>
                 <div>
-                  <p>{userInfo.name}</p>
-                  <Button isIconOnly>
-                    <GrCaretNext />
+                  <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
+                  <Button isIconOnly onPress={handleToggleModal}>
+                    <Image src="/images/edit_mode.svg" alt="edit mode" width={24} height={21} />
                   </Button>
                 </div>
-              </div>
-              <div>
-                <p>로그인정보</p>
                 <div>
-                  <p>{authSNS} 로그인</p>
-                  {authSNS.map((SNS, index) => (
-                    <img key={index} src={`/images/${SNS}.svg`} alt={SNS} width={34} height={31} />
-                  ))}
+                  <div>
+                    <span>
+                      <p>닉네임을 입력해주세요</p>
+                      <p>
+                        {userName.length}/{MAX_NAME_LENGTH}
+                      </p>
+                    </span>
+                    <input type="text" onChange={handleChangeUserName} value={userName} />
+                  </div>
                 </div>
-              </div>
-              <div>
-                <Button>로그아웃</Button>
-              </div>
-            </ModalBody>
-          </>
+                <div>
+                  <Button onPress={handleEditDone}>저장</Button>
+                </div>
+                {toggleModal && (
+                  <ImageUploadModal handleToggleModal={handleToggleModal} setUserProfileURL={setUserProfileURL} />
+                )}
+              </ModalBody>
+            </>
+          ) : (
+            <>
+              <Button isIconOnly onPress={handleClose}>
+                <IoClose />
+              </Button>
+              <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
+              <ModalBody>
+                <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
+                <div>
+                  <p>닉네임</p>
+                  <div>
+                    <p>{userName}</p>
+                    <Button onPress={handleEditMode}>
+                      <GrCaretNext />
+                    </Button>
+                  </div>
+                </div>
+                <div>
+                  <p>로그인정보</p>
+                  <div>
+                    <p>{authSNS} 로그인</p>
+                    {authSNS.map((SNS, index) => (
+                      <img key={index} src={`/images/${SNS}.svg`} alt={SNS} width={34} height={31} />
+                    ))}
+                  </div>
+                </div>
+                <div>
+                  <Button>로그아웃</Button>
+                </div>
+              </ModalBody>
+            </>
+          )}
         </ModalContent>
       </Modal>
     </>

--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -1,13 +1,53 @@
-import { Button } from '@nextui-org/react';
+'use client';
+
+import { Button, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, useDisclosure } from '@nextui-org/react';
 import { PiUserSquareDuotone } from 'react-icons/pi';
 
-const UserProfile = async () => {
+const UserProfile = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleOpen = () => {
+    onOpen();
+  };
   return (
-    <div className="flex gap-4 items-center">
-      <Button isIconOnly aria-label="User Profile Setting">
-        <PiUserSquareDuotone />
-      </Button>
-    </div>
+    <>
+      <div className="flex gap-4 items-center">
+        <Button isIconOnly onPress={handleOpen} aria-label="User Profile Setting">
+          <PiUserSquareDuotone />
+        </Button>
+      </div>
+      <Modal backdrop="blur" isOpen={isOpen} onClose={onClose}>
+        <ModalContent>
+          <>
+            <ModalHeader className="flex flex-col gap-1">Modal Title</ModalHeader>
+            <ModalBody>
+              <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit
+                venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam.
+              </p>
+              <p>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit
+                venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam.
+              </p>
+              <p>
+                Magna exercitation reprehenderit magna aute tempor cupidatat consequat elit dolor adipisicing. Mollit
+                dolor eiusmod sunt ex incididunt cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim laboris
+                do dolor eiusmod. Et mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident Lorem
+                eiusmod et. Culpa deserunt nostrud ad veniam.
+              </p>
+            </ModalBody>
+            <ModalFooter>
+              <Button color="danger" variant="light" onPress={onClose}>
+                Close
+              </Button>
+              <Button color="primary" onPress={onClose}>
+                Action
+              </Button>
+            </ModalFooter>
+          </>
+        </ModalContent>
+      </Modal>
+    </>
   );
 };
 

--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Button, Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, useDisclosure } from '@nextui-org/react';
+import { Button, Modal, ModalContent, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
 import { PiUserSquareDuotone } from 'react-icons/pi';
 
 const UserProfile = () => {
@@ -19,31 +19,27 @@ const UserProfile = () => {
       <Modal backdrop="blur" isOpen={isOpen} onClose={onClose}>
         <ModalContent>
           <>
-            <ModalHeader className="flex flex-col gap-1">Modal Title</ModalHeader>
+            <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
             <ModalBody>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit
-                venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam.
-              </p>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit
-                venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam.
-              </p>
-              <p>
-                Magna exercitation reprehenderit magna aute tempor cupidatat consequat elit dolor adipisicing. Mollit
-                dolor eiusmod sunt ex incididunt cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim laboris
-                do dolor eiusmod. Et mollit incididunt nisi consectetur esse laborum eiusmod pariatur proident Lorem
-                eiusmod et. Culpa deserunt nostrud ad veniam.
-              </p>
+              <p>프로필사진</p>
+              <div>
+                <p>닉네임</p>
+                <div>
+                  <p>유저닉네임</p>
+                  <p>유저 프로필 수정 이동 버튼</p>
+                </div>
+              </div>
+              <div>
+                <p>로그인정보</p>
+                <div>
+                  <p>로그인 소셜 이름</p>
+                  <p>로그인 소셜 아이콘</p>
+                </div>
+              </div>
+              <div>
+                <p>로그아웃버튼</p>
+              </div>
             </ModalBody>
-            <ModalFooter>
-              <Button color="danger" variant="light" onPress={onClose}>
-                Close
-              </Button>
-              <Button color="primary" onPress={onClose}>
-                Action
-              </Button>
-            </ModalFooter>
           </>
         </ModalContent>
       </Modal>

--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -1,10 +1,12 @@
 import { Button } from '@nextui-org/react';
+import { PiUserSquareDuotone } from 'react-icons/pi';
 
 const UserProfile = async () => {
   return (
     <div className="flex gap-4 items-center">
-      <Button isIconOnly color="danger" aria-label="Like"></Button>
-      <Button isIconOnly color="warning" variant="faded" aria-label="Take a photo"></Button>
+      <Button isIconOnly aria-label="User Profile Setting">
+        <PiUserSquareDuotone />
+      </Button>
     </div>
   );
 };

--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { Button, Modal, ModalContent, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
+import { Button, Image, Modal, ModalContent, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
 import { PiUserSquareDuotone } from 'react-icons/pi';
+import { GrCaretNext } from 'react-icons/gr';
 
 export type UserInfoProps = {
   userId: string;
   name: string;
   profileURL: string | null;
-} | null;
+};
 
 const UserProfile = ({ userInfo, authSNS }: { userInfo: UserInfoProps; authSNS: Array<string> }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -26,23 +27,27 @@ const UserProfile = ({ userInfo, authSNS }: { userInfo: UserInfoProps; authSNS: 
           <>
             <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
             <ModalBody>
-              <p>프로필사진</p>
+              <Image width={100} alt="profile_image" src={`${userInfo.profileURL}`} />
               <div>
                 <p>닉네임</p>
                 <div>
-                  <p>유저닉네임</p>
-                  <p>유저 프로필 수정 이동 버튼</p>
+                  <p>{userInfo.name}</p>
+                  <Button isIconOnly>
+                    <GrCaretNext />
+                  </Button>
                 </div>
               </div>
               <div>
                 <p>로그인정보</p>
                 <div>
-                  <p>로그인 소셜 이름</p>
-                  <p>로그인 소셜 아이콘</p>
+                  <p>{authSNS} 로그인</p>
+                  {authSNS.map((SNS, index) => (
+                    <img key={index} src={`/images/${SNS}.svg`} alt={SNS} width={34} height={31} />
+                  ))}
                 </div>
               </div>
               <div>
-                <p>로그아웃버튼</p>
+                <Button>로그아웃</Button>
               </div>
             </ModalBody>
           </>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { createClient } from '@/utils/supabase/server';
 import Logout from '../auth/LogoutButton';
+import UserProfile from '../auth/UserProfileButton';
 import styles from './Header.module.css';
 import Link from 'next/link';
 import { MeetingButton } from '../auth/MeetingButton';
@@ -19,6 +20,7 @@ const Header = async () => {
         {user ? (
           <>
             <Link href="/my-owl">마이페이지</Link>
+            <UserProfile />
             <Logout />
           </>
         ) : (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,8 +5,11 @@ import styles from './Header.module.css';
 import Link from 'next/link';
 import { MeetingButton } from '../auth/MeetingButton';
 
+import { getUserProfileData } from '@/api/supabaseSSR/supabase';
+
 const Header = async () => {
-  const supabase = createClient();
+  const supabase = await createClient();
+  const { userInfo, authSNS } = await getUserProfileData();
 
   const {
     data: { user }
@@ -20,7 +23,7 @@ const Header = async () => {
         {user ? (
           <>
             <Link href="/my-owl">마이페이지</Link>
-            <UserProfile />
+            <UserProfile userInfo={userInfo} authSNS={authSNS} />
             <Logout />
           </>
         ) : (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -23,7 +23,7 @@ const Header = async () => {
         {user ? (
           <>
             <Link href="/my-owl">마이페이지</Link>
-            <UserProfile userInfo={userInfo} authSNS={authSNS} />
+            {userInfo && authSNS && <UserProfile userInfo={userInfo} authSNS={authSNS} />}
             <Logout />
           </>
         ) : (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -8,7 +8,7 @@ import { MeetingButton } from '../auth/MeetingButton';
 import { getUserProfileData } from '@/api/supabaseSSR/supabase';
 
 const Header = async () => {
-  const supabase = await createClient();
+  const supabase = createClient();
   const { userInfo, authSNS } = await getUserProfileData();
 
   const {

--- a/src/components/my-owl/profile/editable/modal/Modal.module.css
+++ b/src/components/my-owl/profile/editable/modal/Modal.module.css
@@ -4,7 +4,8 @@
 
   background-color: rgba(0, 0, 0, 0.4);
 
-  position: absolute;
+  position: fixed;
+  top: 0px;
 
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#99 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 유저 프로필 설정 페이지를 헤더에 속한 유저 프로필 버튼의 모달창으로 바꾸었습니다.
- [x] Next UI를 통해 기본적인 디자인을 만들었고, 기능 전체 정상적으로 작동합니다.
- [x] 기존에 존재하던 my-owl 페이지는 삭제하지 않았습니다. 기능 전체 정상 작동 확인 후 삭제 예정입니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
아직 컴포넌트는 분리하지 않은 상태입니다.
(사실 분리했는데, 제대로 적용되지 않아 현재 브랜치로 커밋 내역 일부를 옮겨서 PR 올렸습니다..ㅎ)
컴포넌트 분리 시 전역으로 관리하거나, props drilling 중 하나를 택해야 합니다.
내일 아침 시도해보고, 잘 되지 않으면 도움 요청하겠습니다.. ㅎㅎ
- 커스텀 디자인은 금요일 저녁/토요일에 일괄 진행 예정입니다
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
컴포넌트 분리 및 의존성 분리가 어렵네요. 
스크린샷에 첨부할 영상 찍다가 에러 발견했는데, 내일 수정해서 PR 올리도록 하겠습니다.
```
## 📸 스크린샷(선택)
![화면 기록 2024-04-12 오전 2 05 17](https://github.com/where-we-meet/owl/assets/69431340/8d720cb2-33a5-4652-aee6-6a2b422e8d47)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
