### PR TITLE
[feat] 기존 Meeting 컴포넌트 내부의 useEffect를 useGetSidebarData.ts 커스텀 훅으로 분리

### DIFF
--- a/src/components/auth/MeetingButton.tsx
+++ b/src/components/auth/MeetingButton.tsx
@@ -4,19 +4,19 @@ import { Meeting } from '../my-owl/meeting/Meeting';
 import { GiHamburgerMenu } from 'react-icons/gi';
 
 export const MeetingButton = () => {
-  const [showSideBar, setShowSideBar] = useState(false);
+  const [showSidebar, setShowSidebar] = useState(false);
 
-  const onChangeSideBarStatus = (e: MouseEvent<HTMLButtonElement>) => {
+  const onChangeSidebarStatus = (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    setShowSideBar(!showSideBar);
+    setShowSidebar(!showSidebar);
   };
 
   return (
     <div>
-      <button className="border-transparent" onClick={(e) => onChangeSideBarStatus(e)}>
+      <button className="border-transparent" onClick={(e) => onChangeSidebarStatus(e)}>
         <GiHamburgerMenu />
       </button>
-      {showSideBar ? <Meeting /> : null}
+      {showSidebar ? <Meeting /> : null}
     </div>
   );
 };

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -1,56 +1,20 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-
-import { getUserMeetingsId, getMyParticipatingRoomsData } from '@/api/supabaseCSR/supabase';
-import { getUserId } from '@/utils/my-owl/getUserId';
-import { sortMeetingInfo } from '@/utils/my-owl/meeting/sortMeetingInfo';
-
 import styles from './Meeting.module.css';
-
-export type UserInfo = {
-  user_id: string;
-  users: {
-    profile_url: string | null;
-  } | null;
-};
-
-export type MeetingInfo = {
-  id: string;
-  name: string | null;
-  confirmed_date: string | null;
-  created_at: string;
-  location: string | null;
-  verified: boolean | null;
-  userdata_room: UserInfo[];
-};
+import { useGetSidebarData } from '@/hooks/useGetSidebarData';
 
 export const Meeting = () => {
-  const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
   const router = useRouter();
-
-  useEffect(() => {
-    const fetchMeetingInfo = async () => {
-      const userId = await getUserId();
-      const roomData = await getUserMeetingsId(userId);
-      const roomIds = roomData.map((item) => item.room_id);
-      const fetchedData = await getMyParticipatingRoomsData(roomIds);
-      const sortedData = sortMeetingInfo(fetchedData);
-      setMeetingInfo(sortedData);
-    };
-
-    fetchMeetingInfo();
-
-  }, []);
+  const SidebarData = useGetSidebarData();
 
   const handleClickRoom = (roomId: string | null) => {
     router.push(`/room/${roomId}`);
   };
-  
+
   return (
     <div className={styles.meeting_container}>
-      {meetingInfo.map((meeting, index) => (
+      {SidebarData.map((meeting, index) => (
         <div key={index} className={styles.rooms_box} onClick={() => handleClickRoom(meeting.id)}>
           <div className={styles.room_box}>
             <div className={styles.room_box_left}>

--- a/src/hooks/useGetSidebarData.ts
+++ b/src/hooks/useGetSidebarData.ts
@@ -1,0 +1,43 @@
+'use client';
+
+import { getMyParticipatingRoomsData, getUserMeetingsId } from '@/api/supabaseCSR/supabase';
+import { getUserId } from '@/utils/my-owl/getUserId';
+import { sortMeetingInfo } from '@/utils/my-owl/meeting/sortMeetingInfo';
+import { useEffect, useState } from 'react';
+
+export type UserInfo = {
+  user_id: string;
+  users: {
+    profile_url: string | null;
+  } | null;
+};
+
+export type MeetingInfo = {
+  id: string;
+  name: string | null;
+  confirmed_date: string | null;
+  created_at: string;
+  location: string | null;
+  verified: boolean | null;
+  userdata_room: UserInfo[];
+};
+
+export const useGetSidebarData = () => {
+const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
+
+  useEffect(() => {
+    const fetchMeetingInfo = async () => {
+      const userId = await getUserId();
+      const roomData = await getUserMeetingsId(userId);
+      const roomIds = roomData.map((item) => item.room_id);
+      const fetchedData = await getMyParticipatingRoomsData(roomIds);
+      const sortedData = sortMeetingInfo(fetchedData);
+
+      setMeetingInfo(sortedData);
+    };
+
+    fetchMeetingInfo();
+  }, []);
+
+  return meetingInfo
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
 #119
 #85 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x]  my-owl/Meeting.tsx 내부로직을 수정
- [x]  useEffect로 호출중인 supabase 로직을 커스텀 훅으로 분리

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
1. Meeting 컴포넌트 내부에 존재하는 useEffect 로직을 커스 텀훅으로 분리했습니다.
2. Meeting 컴포넌트 내부에는 ui로직만 존재하도록 변경하였으며, 변수의 이름을 SidebarData로 작성하여 직관적인 판단이 가능해졌습니다
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. 변수 작명에 있어서 직관적인 내용 파악이 가능하게 만들게 되었습니다.
```
## 📸 스크린샷(선택)
![sidebar_test](https://github.com/where-we-meet/owl/assets/109938441/eb55af8e-d33a-45ce-baa5-b87374043cb8)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
