### PR TITLE
[feat] NextUI를 통해 버튼, 모달창 구현

### DIFF
--- a/src/components/auth/MeetingButton.tsx
+++ b/src/components/auth/MeetingButton.tsx
@@ -1,22 +1,24 @@
 'use client';
-import { MouseEvent, useState } from 'react';
 import { Meeting } from '../my-owl/meeting/Meeting';
 import { GiHamburgerMenu } from 'react-icons/gi';
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, useDisclosure } from '@nextui-org/react';
 
 export const MeetingButton = () => {
-  const [showSidebar, setShowSidebar] = useState(false);
-
-  const onChangeSidebarStatus = (e: MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    setShowSidebar(!showSidebar);
-  };
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <div>
-      <button className="border-transparent" onClick={(e) => onChangeSidebarStatus(e)}>
+      <Button onClick={onOpen} isIconOnly className="border-transparent">
         <GiHamburgerMenu />
-      </button>
-      {showSidebar ? <Meeting /> : null}
+      </Button>
+      <Modal backdrop="blur" size="3xl" isOpen={isOpen} onOpenChange={onClose}>
+        <ModalContent>
+          <ModalBody>
+            <Meeting />
+          </ModalBody>
+          <ModalFooter />
+        </ModalContent>
+      </Modal>
     </div>
   );
 };

--- a/src/components/my-owl/meeting/Meeting.module.css
+++ b/src/components/my-owl/meeting/Meeting.module.css
@@ -3,14 +3,18 @@
   background-color: gray;
 
   height: 80vh;
-  width: 70vw;
+  width: 95%;
 
   overflow-y: scroll;
 }
 
+.meeting_container :hover {
+  background-color: rgb(158, 158, 158);
+}
+
 .rooms_box {
   padding: 10px;
-
+  min-width: 90%;
   display: flex;
   flex-direction: column;
 }

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -3,10 +3,20 @@
 import { useRouter } from 'next/navigation';
 import styles from './Meeting.module.css';
 import { useGetSidebarData } from '@/hooks/useGetSidebarData';
+import { useEffect, useState } from 'react';
+import { Skeleton } from '@nextui-org/react';
 
 export const Meeting = () => {
   const router = useRouter();
-  const SidebarData = useGetSidebarData();
+  const sidebarData = useGetSidebarData();
+  const [isLoaded, setIsLoaded] = useState(false);
+  console.log('sidebar Data', sidebarData);
+
+  useEffect(() => {
+    if (sidebarData) {
+      setIsLoaded(true)
+    }
+  },[sidebarData])
 
   const handleClickRoom = (roomId: string | null) => {
     router.push(`/room/${roomId}`);
@@ -14,27 +24,29 @@ export const Meeting = () => {
 
   return (
     <div className={styles.meeting_container}>
-      {SidebarData.map((meeting, index) => (
+      {sidebarData.map((meeting, index) => (
         <div key={index} className={styles.rooms_box} onClick={() => handleClickRoom(meeting.id)}>
-          <div className={styles.room_box}>
-            <div className={styles.room_box_left}>
-              <h3>{meeting.name}</h3>
-              <p>날짜 : {meeting.confirmed_date}</p>
-              <p>위치 : {meeting.location}</p>
-            </div>
-            <div className={styles.room_box_right}>
-              <div className={styles.participants_container}>
-                {meeting.userdata_room.map((participant, index) => (
-                  <div
-                    className={styles.participant_profile}
-                    style={{ backgroundImage: `url(${participant.users?.profile_url})` }}
-                    key={index}
-                  />
-                ))}
+          <Skeleton isLoaded={isLoaded} className="rounded-lg">
+            <div className={styles.room_box}>
+              <div className={styles.room_box_left}>
+                <h3>{meeting.name}</h3>
+                <p>날짜 : {meeting.confirmed_date}</p>
+                <p>위치 : {meeting.location}</p>
               </div>
-              <p>{meeting.userdata_room.length}명 참여중</p>
+              <div className={styles.room_box_right}>
+                <div className={styles.participants_container}>
+                  {meeting.userdata_room.map((participant, index) => (
+                    <div
+                      className={styles.participant_profile}
+                      style={{ backgroundImage: `url(${participant.users?.profile_url})` }}
+                      key={index}
+                    />
+                  ))}
+                </div>
+                <p>{meeting.userdata_room.length}명 참여중</p>
+              </div>
             </div>
-          </div>
+          </Skeleton>
         </div>
       ))}
     </div>

--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -2,21 +2,20 @@
 
 import { useRouter } from 'next/navigation';
 import styles from './Meeting.module.css';
-import { useGetSidebarData } from '@/hooks/useGetSidebarData';
+import { useGetModalData } from '@/hooks/useGetSidebarData';
 import { useEffect, useState } from 'react';
 import { Skeleton } from '@nextui-org/react';
 
 export const Meeting = () => {
   const router = useRouter();
-  const sidebarData = useGetSidebarData();
+  const ModalData = useGetModalData();
   const [isLoaded, setIsLoaded] = useState(false);
-  console.log('sidebar Data', sidebarData);
 
   useEffect(() => {
-    if (sidebarData) {
-      setIsLoaded(true)
+    if (ModalData) {
+      setIsLoaded(true);
     }
-  },[sidebarData])
+  }, [ModalData]);
 
   const handleClickRoom = (roomId: string | null) => {
     router.push(`/room/${roomId}`);
@@ -24,7 +23,7 @@ export const Meeting = () => {
 
   return (
     <div className={styles.meeting_container}>
-      {sidebarData.map((meeting, index) => (
+      {ModalData.map((meeting, index) => (
         <div key={index} className={styles.rooms_box} onClick={() => handleClickRoom(meeting.id)}>
           <Skeleton isLoaded={isLoaded} className="rounded-lg">
             <div className={styles.room_box}>

--- a/src/hooks/useGetSidebarData.ts
+++ b/src/hooks/useGetSidebarData.ts
@@ -22,7 +22,7 @@ export type MeetingInfo = {
   userdata_room: UserInfo[];
 };
 
-export const useGetSidebarData = () => {
+export const useGetModalData = () => {
 const [meetingInfo, setMeetingInfo] = useState<MeetingInfo[]>([]);
 
   useEffect(() => {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #102 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] Meeting 컴포넌트를 외부로 분리
- [x] 상호작용 시 사이드에서 출력되는 디자인 추가

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
사이드바를 전역에서 사용 할 수 있게 변경하였습니다.
사이드바 대신 글로벌 모달이라는 이름으로 변경하였습니다.

```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. 사이드바 대신 모달창을 이용한 디자인을 채택
1-1. 모달창에는 사이드에서 출력되는 기능이 nextui에 존재하지 않았음
1-2. 모달창으로 변경하며 전반적인 컴포넌트의 이름을 변경
```
## 📸 스크린샷(선택)
![modal](https://github.com/where-we-meet/owl/assets/109938441/cbb487bd-9894-46b7-9f60-1b14cb042e03)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
