### PR TITLE
[Feature/header userprofile] 유저 프로필 설정 관련 컴포넌트 분리 및 리팩터링, 기타 에러 수정

### DIFF
--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -1,33 +1,14 @@
 'use client';
 
 import { Button, Modal, ModalContent, useDisclosure } from '@nextui-org/react';
-import { PiUserSquareDuotone } from 'react-icons/pi';
-import { useEffect, useState } from 'react';
-import { useQueryUser } from '@/hooks/useQueryUser';
-import { getUserProfileData } from '@/api/profile';
-import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
 import UserProfileUpdate from './UserProfileUpdate';
 import UserProfileRead from './UserProfileRead';
+import { PiUserSquareDuotone } from 'react-icons/pi';
 
 const UserProfile = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [editMode, setEditMode] = useState(false);
-
-  const [userName, setUserName] = useState('');
-  const [userProfileURL, setUserProfileURL] = useState<string | null>('');
-
-  const user = useQueryUser();
-  const { data, isLoading } = useQuery({
-    queryKey: ['profile'],
-    queryFn: () => getUserProfileData(user.id)
-  });
-
-  useEffect(() => {
-    if (data) {
-      setUserName(data.name);
-      setUserProfileURL(data.profile_url);
-    }
-  }, [data]);
 
   const handleOpen = () => {
     onOpen();
@@ -49,17 +30,16 @@ const UserProfile = () => {
           <PiUserSquareDuotone />
         </Button>
       </div>
-      {data && (
-        <Modal backdrop="blur" isOpen={isOpen} onClose={handleClose} hideCloseButton>
-          <ModalContent>
-            {editMode ? (
-              <UserProfileUpdate toggleEditMode={toggleEditMode} />
-            ) : (
-              <UserProfileRead toggleEditMode={toggleEditMode} />
-            )}
-          </ModalContent>
-        </Modal>
-      )}
+
+      <Modal backdrop="blur" isOpen={isOpen} onClose={handleClose} hideCloseButton>
+        <ModalContent>
+          {editMode ? (
+            <UserProfileUpdate toggleEditMode={toggleEditMode} />
+          ) : (
+            <UserProfileRead toggleEditMode={toggleEditMode} handleClose={handleClose} />
+          )}
+        </ModalContent>
+      </Modal>
     </>
   );
 };

--- a/src/components/auth/UserProfileButton.tsx
+++ b/src/components/auth/UserProfileButton.tsx
@@ -1,29 +1,20 @@
 'use client';
 
-import { Button, Image, Modal, ModalContent, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
+import { Button, Modal, ModalContent, useDisclosure } from '@nextui-org/react';
 import { PiUserSquareDuotone } from 'react-icons/pi';
-import { GrCaretNext } from 'react-icons/gr';
-import { IoClose, IoChevronBack } from 'react-icons/io5';
-import { ChangeEvent, useEffect, useState } from 'react';
-import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
-import { ImageUploadModal } from '../my-owl/profile/modal/Modal';
+import { useEffect, useState } from 'react';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
 import { useQuery } from '@tanstack/react-query';
-
-export type UserInfo = {
-  name: string;
-  profile_url: string | null;
-};
-
-const MAX_NAME_LENGTH = 16;
+import UserProfileUpdate from './UserProfileUpdate';
+import UserProfileRead from './UserProfileRead';
 
 const UserProfile = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [editMode, setEditMode] = useState(false);
+
   const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
-  const [toggleModal, setToggleModal] = useState(false);
 
   const user = useQueryUser();
   const { data, isLoading } = useQuery({
@@ -38,29 +29,6 @@ const UserProfile = () => {
     }
   }, [data]);
 
-  const handleToggleModal = () => {
-    setToggleModal((prev) => !prev);
-  };
-
-  const handleChangeUserName = (event: ChangeEvent<HTMLInputElement>) => {
-    const name = event.target.value;
-    setUserName(name);
-  };
-
-  const handleEditDone = async () => {
-    if (userName.length < 1) {
-      alert('닉네임은 최소 1글자 이상으로 지어주세요.');
-    } else if (userName.length > 16) {
-      alert('닉네임은 최대 16글자 이하로 지어주세요.');
-    } else {
-      await updateUserName(user.id, userName);
-      if (userProfileURL !== null) {
-        await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
-      }
-      setEditMode(false);
-    }
-  };
-
   const handleOpen = () => {
     onOpen();
   };
@@ -70,7 +38,7 @@ const UserProfile = () => {
     onClose();
   };
 
-  const handleEditMode = () => {
+  const toggleEditMode = () => {
     setEditMode((prev) => !prev);
   };
 
@@ -85,67 +53,9 @@ const UserProfile = () => {
         <Modal backdrop="blur" isOpen={isOpen} onClose={handleClose} hideCloseButton>
           <ModalContent>
             {editMode ? (
-              <>
-                <Button isIconOnly onPress={handleEditMode}>
-                  <IoChevronBack />
-                </Button>
-                <ModalHeader className="flex flex-col gap-1">프로필 수정</ModalHeader>
-                <ModalBody>
-                  <div>
-                    <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
-                    <Button isIconOnly onPress={handleToggleModal}>
-                      <Image src="/images/edit_mode.svg" alt="edit mode" width={24} height={21} />
-                    </Button>
-                  </div>
-                  <div>
-                    <div>
-                      <span>
-                        <p>닉네임을 입력해주세요</p>
-                        <p>
-                          {userName.length}/{MAX_NAME_LENGTH}
-                        </p>
-                      </span>
-                      <input type="text" onChange={handleChangeUserName} value={userName} />
-                    </div>
-                  </div>
-                  <div>
-                    <Button onPress={handleEditDone}>저장</Button>
-                  </div>
-                  {toggleModal && (
-                    <ImageUploadModal handleToggleModal={handleToggleModal} setUserProfileURL={setUserProfileURL} />
-                  )}
-                </ModalBody>
-              </>
+              <UserProfileUpdate toggleEditMode={toggleEditMode} />
             ) : (
-              <>
-                <Button isIconOnly onPress={handleClose}>
-                  <IoClose />
-                </Button>
-                <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
-                <ModalBody>
-                  <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
-                  <div>
-                    <p>닉네임</p>
-                    <div>
-                      <p>{data.name}</p>
-                      <Button onPress={handleEditMode}>
-                        <GrCaretNext />
-                      </Button>
-                    </div>
-                  </div>
-                  <div>
-                    <p>로그인정보</p>
-                    <div>
-                      {user.app_metadata.providers.map((SNS: string, index: number) => (
-                        <img key={index} src={`/images/${SNS}.svg`} alt={SNS} width={34} height={31} />
-                      ))}
-                    </div>
-                  </div>
-                  <div>
-                    <Button>로그아웃</Button>
-                  </div>
-                </ModalBody>
-              </>
+              <UserProfileRead toggleEditMode={toggleEditMode} />
             )}
           </ModalContent>
         </Modal>

--- a/src/components/auth/UserProfileRead.tsx
+++ b/src/components/auth/UserProfileRead.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { Button, Image, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
+import { GrCaretNext } from 'react-icons/gr';
+import { IoClose } from 'react-icons/io5';
+import { useEffect, useState } from 'react';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { getUserProfileData } from '@/api/profile';
+import { useQuery } from '@tanstack/react-query';
+
+export type UserInfo = {
+  name: string;
+  profile_url: string | null;
+};
+
+const UserProfileRead = () => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const [editMode, setEditMode] = useState(false);
+  const [userName, setUserName] = useState('');
+  const [userProfileURL, setUserProfileURL] = useState<string | null>('');
+
+  const { data: user } = useQueryUser();
+  const { data, isLoading } = useQuery({
+    queryKey: ['profile'],
+    queryFn: () => getUserProfileData(user.id)
+  });
+
+  useEffect(() => {
+    if (data) {
+      setUserName(data.name);
+      setUserProfileURL(data.profile_url);
+    }
+  }, [data]);
+
+  const handleClose = () => {
+    setEditMode(false);
+    onClose();
+  };
+
+  const handleEditMode = () => {
+    setEditMode((prev) => !prev);
+  };
+
+  return (
+    <>
+      <Button isIconOnly onPress={handleClose}>
+        <IoClose />
+      </Button>
+      <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
+      <ModalBody>
+        <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
+        <div>
+          <p>닉네임</p>
+          <div>
+            <p>{data?.name}</p>
+            <Button onPress={handleEditMode}>
+              <GrCaretNext />
+            </Button>
+          </div>
+        </div>
+        <div>
+          <p>로그인정보</p>
+          <div>
+            {user.app_metadata.providers.map((SNS: string, index: number) => (
+              <img key={index} src={`/images/${SNS}.svg`} alt={SNS} width={34} height={31} />
+            ))}
+          </div>
+        </div>
+        <div>
+          <Button>로그아웃</Button>
+        </div>
+      </ModalBody>
+    </>
+  );
+};
+
+export default UserProfileRead;

--- a/src/components/auth/UserProfileRead.tsx
+++ b/src/components/auth/UserProfileRead.tsx
@@ -1,24 +1,16 @@
 'use client';
 
-import { Button, Image, ModalHeader, ModalBody, useDisclosure } from '@nextui-org/react';
+import { useEffect, useState } from 'react';
+import { Button, Image, ModalHeader, ModalBody } from '@nextui-org/react';
+import { getUserProfileData } from '@/api/profile';
+import { useQueryUser } from '@/hooks/useQueryUser';
 import { GrCaretNext } from 'react-icons/gr';
 import { IoClose } from 'react-icons/io5';
-import { useEffect, useState } from 'react';
-import { useQueryUser } from '@/hooks/useQueryUser';
-import { getUserProfileData } from '@/api/profile';
-import { useQuery } from '@tanstack/react-query';
 
 export type UserProfileData = { name: string; profile_url: string | null };
 
-const UserProfileRead = ({ toggleEditMode }: { toggleEditMode: () => void }) => {
-  const { onClose } = useDisclosure();
-  const [userProfileURL, setUserProfileURL] = useState<string | null>('');
-
+const UserProfileRead = ({ toggleEditMode, handleClose }: { toggleEditMode: () => void; handleClose: () => void }) => {
   const { data: user } = useQueryUser();
-
-  /**
-   * 실험실
-   */
   //state for recent profile data (from supabase DB)
   const [data, setData] = useState<UserProfileData>({
     name: '',
@@ -37,11 +29,6 @@ const UserProfileRead = ({ toggleEditMode }: { toggleEditMode: () => void }) => 
     };
     fetchData();
   });
-
-  const handleClose = () => {
-    toggleEditMode();
-    onClose();
-  };
 
   return (
     <>

--- a/src/components/auth/UserProfileRead.tsx
+++ b/src/components/auth/UserProfileRead.tsx
@@ -10,7 +10,8 @@ import { IoClose } from 'react-icons/io5';
 export type UserProfileData = { name: string; profile_url: string | null };
 
 const UserProfileRead = ({ toggleEditMode, handleClose }: { toggleEditMode: () => void; handleClose: () => void }) => {
-  const { data: user } = useQueryUser();
+  const user = useQueryUser();
+
   //state for recent profile data (from supabase DB)
   const [data, setData] = useState<UserProfileData>({
     name: '',
@@ -28,7 +29,7 @@ const UserProfileRead = ({ toggleEditMode, handleClose }: { toggleEditMode: () =
       }
     };
     fetchData();
-  });
+  }, []);
 
   return (
     <>

--- a/src/components/auth/UserProfileRead.tsx
+++ b/src/components/auth/UserProfileRead.tsx
@@ -8,23 +8,35 @@ import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
 import { useQuery } from '@tanstack/react-query';
 
+export type UserProfileData = { name: string; profile_url: string | null };
+
 const UserProfileRead = ({ toggleEditMode }: { toggleEditMode: () => void }) => {
   const { onClose } = useDisclosure();
-  const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
 
   const { data: user } = useQueryUser();
-  const { data, isLoading } = useQuery({
-    queryKey: ['profile'],
-    queryFn: () => getUserProfileData(user.id)
+
+  /**
+   * 실험실
+   */
+  //state for recent profile data (from supabase DB)
+  const [data, setData] = useState<UserProfileData>({
+    name: '',
+    profile_url: ''
   });
 
+  // useEffect for take recent data
   useEffect(() => {
-    if (data) {
-      setUserName(data.name);
-      setUserProfileURL(data.profile_url);
-    }
-  }, [data]);
+    const fetchData = async () => {
+      try {
+        const data = await getUserProfileData(user.id);
+        setData({ name: data.name, profile_url: data.profile_url });
+      } catch (error) {
+        console.error('Error fetching user profile data:', error);
+      }
+    };
+    fetchData();
+  });
 
   const handleClose = () => {
     toggleEditMode();
@@ -38,11 +50,11 @@ const UserProfileRead = ({ toggleEditMode }: { toggleEditMode: () => void }) => 
       </Button>
       <ModalHeader className="flex flex-col gap-1">계정 정보</ModalHeader>
       <ModalBody>
-        <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
+        <Image width={100} alt="profile_image" src={`${data.profile_url}`} />
         <div>
           <p>닉네임</p>
           <div>
-            <p>{data?.name}</p>
+            <p>{data.name}</p>
             <Button onPress={toggleEditMode}>
               <GrCaretNext />
             </Button>

--- a/src/components/auth/UserProfileRead.tsx
+++ b/src/components/auth/UserProfileRead.tsx
@@ -8,14 +8,8 @@ import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
 import { useQuery } from '@tanstack/react-query';
 
-export type UserInfo = {
-  name: string;
-  profile_url: string | null;
-};
-
-const UserProfileRead = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const [editMode, setEditMode] = useState(false);
+const UserProfileRead = ({ toggleEditMode }: { toggleEditMode: () => void }) => {
+  const { onClose } = useDisclosure();
   const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
 
@@ -33,12 +27,8 @@ const UserProfileRead = () => {
   }, [data]);
 
   const handleClose = () => {
-    setEditMode(false);
+    toggleEditMode();
     onClose();
-  };
-
-  const handleEditMode = () => {
-    setEditMode((prev) => !prev);
   };
 
   return (
@@ -53,7 +43,7 @@ const UserProfileRead = () => {
           <p>닉네임</p>
           <div>
             <p>{data?.name}</p>
-            <Button onPress={handleEditMode}>
+            <Button onPress={toggleEditMode}>
               <GrCaretNext />
             </Button>
           </div>

--- a/src/components/auth/UserProfileUpdate.tsx
+++ b/src/components/auth/UserProfileUpdate.tsx
@@ -9,15 +9,9 @@ import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
 import { useQuery } from '@tanstack/react-query';
 
-export type UserInfo = {
-  name: string;
-  profile_url: string | null;
-};
-
 const MAX_NAME_LENGTH = 16;
 
-const UserProfileUpdate = () => {
-  const [editMode, setEditMode] = useState(false);
+const UserProfileUpdate = ({ toggleEditMode }: { toggleEditMode: () => void }) => {
   const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
   const [toggleModal, setToggleModal] = useState(false);
@@ -54,12 +48,12 @@ const UserProfileUpdate = () => {
       if (userProfileURL !== null) {
         await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
       }
-      setEditMode(false);
+      toggleEditMode();
     }
   };
 
   const handleEditExit = () => {
-    setEditMode((prev) => !prev);
+    toggleEditMode();
   };
 
   return (

--- a/src/components/auth/UserProfileUpdate.tsx
+++ b/src/components/auth/UserProfileUpdate.tsx
@@ -16,7 +16,7 @@ const UserProfileUpdate = ({ toggleEditMode }: { toggleEditMode: () => void }) =
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
   const [toggleModal, setToggleModal] = useState(false);
 
-  const { data: user } = useQueryUser();
+  const user = useQueryUser();
   const { data, isLoading } = useQuery({
     queryKey: ['profile'],
     queryFn: () => getUserProfileData(user.id)

--- a/src/components/auth/UserProfileUpdate.tsx
+++ b/src/components/auth/UserProfileUpdate.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { Button, Image, ModalHeader, ModalBody } from '@nextui-org/react';
-import { IoChevronBack } from 'react-icons/io5';
 import { ChangeEvent, useEffect, useState } from 'react';
-import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
-import { ImageUploadModal } from '../my-owl/profile/modal/Modal';
-import { useQueryUser } from '@/hooks/useQueryUser';
-import { getUserProfileData } from '@/api/profile';
 import { useQuery } from '@tanstack/react-query';
+import { Button, Image, ModalHeader, ModalBody } from '@nextui-org/react';
+import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
+import { getUserProfileData } from '@/api/profile';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { ImageUploadModal } from '../my-owl/profile/modal/Modal';
+import { IoChevronBack } from 'react-icons/io5';
 
 const MAX_NAME_LENGTH = 16;
 
@@ -21,13 +21,6 @@ const UserProfileUpdate = ({ toggleEditMode }: { toggleEditMode: () => void }) =
     queryKey: ['profile'],
     queryFn: () => getUserProfileData(user.id)
   });
-
-  useEffect(() => {
-    if (data) {
-      setUserName(data.name);
-      setUserProfileURL(data.profile_url);
-    }
-  }, [data]);
 
   const handleToggleModal = () => {
     setToggleModal((prev) => !prev);
@@ -52,13 +45,16 @@ const UserProfileUpdate = ({ toggleEditMode }: { toggleEditMode: () => void }) =
     }
   };
 
-  const handleEditExit = () => {
-    toggleEditMode();
-  };
+  useEffect(() => {
+    if (data) {
+      setUserName(data.name);
+      setUserProfileURL(data.profile_url);
+    }
+  }, [data]);
 
   return (
     <>
-      <Button isIconOnly onPress={handleEditExit}>
+      <Button isIconOnly onPress={toggleEditMode}>
         <IoChevronBack />
       </Button>
       <ModalHeader className="flex flex-col gap-1">프로필 수정</ModalHeader>

--- a/src/components/auth/UserProfileUpdate.tsx
+++ b/src/components/auth/UserProfileUpdate.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { Button, Image, ModalHeader, ModalBody } from '@nextui-org/react';
+import { IoChevronBack } from 'react-icons/io5';
+import { ChangeEvent, useEffect, useState } from 'react';
+import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
+import { ImageUploadModal } from '../my-owl/profile/modal/Modal';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { getUserProfileData } from '@/api/profile';
+import { useQuery } from '@tanstack/react-query';
+
+export type UserInfo = {
+  name: string;
+  profile_url: string | null;
+};
+
+const MAX_NAME_LENGTH = 16;
+
+const UserProfileUpdate = () => {
+  const [editMode, setEditMode] = useState(false);
+  const [userName, setUserName] = useState('');
+  const [userProfileURL, setUserProfileURL] = useState<string | null>('');
+  const [toggleModal, setToggleModal] = useState(false);
+
+  const { data: user } = useQueryUser();
+  const { data, isLoading } = useQuery({
+    queryKey: ['profile'],
+    queryFn: () => getUserProfileData(user.id)
+  });
+
+  useEffect(() => {
+    if (data) {
+      setUserName(data.name);
+      setUserProfileURL(data.profile_url);
+    }
+  }, [data]);
+
+  const handleToggleModal = () => {
+    setToggleModal((prev) => !prev);
+  };
+
+  const handleChangeUserName = (event: ChangeEvent<HTMLInputElement>) => {
+    const name = event.target.value;
+    setUserName(name);
+  };
+
+  const handleEditDone = async () => {
+    if (userName.length < 1) {
+      alert('닉네임은 최소 1글자 이상으로 지어주세요.');
+    } else if (userName.length > 16) {
+      alert('닉네임은 최대 16글자 이하로 지어주세요.');
+    } else {
+      await updateUserName(user.id, userName);
+      if (userProfileURL !== null) {
+        await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
+      }
+      setEditMode(false);
+    }
+  };
+
+  const handleEditExit = () => {
+    setEditMode((prev) => !prev);
+  };
+
+  return (
+    <>
+      <Button isIconOnly onPress={handleEditExit}>
+        <IoChevronBack />
+      </Button>
+      <ModalHeader className="flex flex-col gap-1">프로필 수정</ModalHeader>
+      <ModalBody>
+        <div>
+          <Image width={100} alt="profile_image" src={`${userProfileURL}`} />
+          <Button isIconOnly onPress={handleToggleModal}>
+            <Image src="/images/edit_mode.svg" alt="edit mode" width={24} height={21} />
+          </Button>
+        </div>
+        <div>
+          <div>
+            <span>
+              <p>닉네임을 입력해주세요</p>
+              <p>
+                {userName.length}/{MAX_NAME_LENGTH}
+              </p>
+            </span>
+            <input type="text" onChange={handleChangeUserName} value={userName} />
+          </div>
+        </div>
+        <div>
+          <Button onPress={handleEditDone}>저장</Button>
+        </div>
+        {toggleModal && (
+          <ImageUploadModal handleToggleModal={handleToggleModal} setUserProfileURL={setUserProfileURL} />
+        )}
+      </ModalBody>
+    </>
+  );
+};
+
+export default UserProfileUpdate;

--- a/src/components/my-owl/profile/modal/Modal.tsx
+++ b/src/components/my-owl/profile/modal/Modal.tsx
@@ -30,7 +30,7 @@ export const ImageUploadModal = ({
 
   const handleChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
-    if (files !== null) {
+    if (files !== null && files !== undefined) {
       const file = files[0];
       if (fileChangeValidation(file)) setFile(file);
       else {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #134
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 유저 프로필 설정 관련 컴포넌트 분리 및 리팩터링
- [x] 데이터 관리 흐름 수정
- [x] 추가 발생한 에러 보수

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
데이터 관리 흐름을 수정하고, 유저 프로필 설정과 관련된 코드들을 리팩터링 및 컴포넌트 분리를 진행하였습니다.
또한, 파일 업로드와 관련해 발생한 에러(유저가 파일을 선택하지 않은 경우)를 핸들링하는 로직을 추가해 버그를 잡았습니다.
```
추후 @gidalim 님과 UserProfile 등 헤더 관련 컴포넌트들을 적당한 파일을 만들어 옮기면 좋을 것 같아요.
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
![IMG_9596](https://github.com/where-we-meet/owl/assets/69431340/065ec1aa-9fc6-4b49-8eca-54b0f42d0fad)

```
  useQuery를 통해 유저 데이터를 가져오는 과정에서 수정 완료 후에 유저 프로필 조회 화면으로 넘어가면 
가장 최신의 데이터가 아닌 이전의 데이터를 보여주는 문제가 있었습니다. 
또한, 수정 중 모달 밖을 나가는 경우에도 이전의 수정 사항이 저장되는 문제가 있었습니다.

  이러한 문제를 해결하기 위해 데이터 관리 흐름을 위 사진과 같이 기획, 변경하였습니다. 
useQuery 대신 useEffect를 통해 렌더링 될 때마다 가장 최근에 데이터를 fetching하도록 하는 등, 
각 모달 화면에 맞는 데이터 fetching 로직을 작성하였습니다. supabase로부터 가장 최신의 data를 가져옵니다.

  데이터 관리 흐름을 바꾸며 코드 리팩터링도 함께 진행하였는데, 이전보다 훨씬 깔끔한 코드가 되어 기분이 좋네요:-)
  
 또한, 유저가 파일 선택을 취소 한 경우 에러가 발생하는 문제가 있었습니다. 이는 Undefined인 경우를 처리해줌으로서 해결하였습니다.

```
## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
