### PR TITLE
[refactor/calendar] selectedDate를 zustand를 이용하여 전역상태로 관리

### DIFF
--- a/src/components/room/meeting/calender/Calender.tsx
+++ b/src/components/room/meeting/calender/Calender.tsx
@@ -7,7 +7,9 @@ import styles from './Calender.module.css';
 import EntireOfMonth from './EntireOfMonth';
 import checkSelectedDates from './checkSelectedDates';
 
+import { useCalendarStore } from '@/store/calendarStore';
 import { useGetCalendar } from '@/hooks/useGetCalendar';
+
 import { createClient } from '@/utils/supabase/client';
 import { getCurrentUserData } from '@/api/supabaseCSR/supabase';
 import { useParams } from 'next/navigation';
@@ -19,7 +21,7 @@ const Calender = () => {
   const { id }: { id: string } = useParams();
 
   const [nowDate, setNowDate] = useState<Date>(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date[]>([]);
+  const { selectedDate, setSelectedDate } = useCalendarStore();
 
   const { userSchedules } = useGetCalendar(id);
 
@@ -28,16 +30,20 @@ const Calender = () => {
   };
 
   const afterMonth = () => {
-    setNowDate(addMonths(nowDate, 1));
+    setNowDate((prev) => {
+      return addMonths(prev, 1);
+    });
   };
 
   const handleDateClick = (date: Date) => {
     const isAlreadySelected = selectedDate.some((selected) => isSameDay(selected, date));
 
     if (isAlreadySelected) {
-      setSelectedDate((prev) => prev.filter((selected) => !isSameDay(selected, date)));
+      const filteredDate = selectedDate.filter((item) => !isSameDay(item, date));
+      setSelectedDate(filteredDate);
     } else {
-      setSelectedDate((prev) => [...prev, date]);
+      const newDateList = [...selectedDate, date];
+      setSelectedDate(newDateList);
     }
   };
 

--- a/src/store/calendarStore.ts
+++ b/src/store/calendarStore.ts
@@ -1,0 +1,10 @@
+import { create } from 'zustand';
+
+interface CalendarState {
+  selectedDate: Date[];
+  setSelectedDate: (selectedDate: Date[]) => void;
+}
+export const useCalendarStore = create<CalendarState>((set) => ({
+  selectedDate: [],
+  setSelectedDate: (selectedDate) => set({ selectedDate })
+}));


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] zustand를 이용하여 전역상태로 관리할 수 있게 변경했습니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
type 선언 오류가 떴는데, 상태 하나로 두 개의 로직을 한꺼번에 처리하려고 하니 발생하는 문제였습니다.
변경된 값을 각각 setSelectedDate에 담을 수 있게 변경하였습니다.
```
## 📸 스크린샷(선택)
<img width="434" alt="image" src="https://github.com/where-we-meet/owl/assets/154496294/0e7e64cb-2f37-4d5f-951d-e856984e3888">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
