### PR TITLE
[feat/fix] 시작 일자 이전 날짜 선택 차단,실시간 구독 문제, 유저데이터 가끔 못가져오는 문제 수정

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,6 +1,7 @@
-import { SupabaseClient } from '@supabase/supabase-js';
+import { createClient } from '@/utils/supabase/server';
 
-export const getSession = async (supabase: SupabaseClient) => {
+export const getSession = async () => {
+  const supabase = createClient();
   const {
     data: { user },
     error

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -109,22 +109,6 @@ export const getUserMeetingsId = async (userId: string) => {
   return [];
 };
 
-type Schedule = Tables<'room_schedule'>;
-
-export const getRealtimeScheduleData = (id: string) => {
-  const subscription = supabase
-    .channel('schedule')
-    .on(
-      'postgres_changes',
-      { event: '*', schema: 'public', table: 'room_schedule', filter: `room_id=eq.${id}` },
-      async (payload) => {
-        console.log('날짜 적용 됨', payload);
-      }
-    )
-    .subscribe();
-  return subscription;
-};
-
 // Insert rows
 
 export const updateStartLocation = async (payload: UserLocationData) => {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -21,12 +21,12 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const supabase = createClient();
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery<User | null>({
     queryKey: ['auth'],
-    queryFn: () => getSession(supabase)
+    queryFn: getSession,
+    gcTime: Infinity
   });
 
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import Providers from './providers';
 import './globals.css';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { getSession } from '@/api/auth';
-import { createClient } from '@/utils/supabase/server';
 import getQueryClient from '@/utils/getQueryClient';
 import type { User } from '@supabase/supabase-js';
 

--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -1,26 +1,8 @@
-'use client';
-
 import Meeting from '@/components/room/meeting/Meeting';
 import Sidebar from '@/components/room/sidebar/Sidebar';
-import { useGetRoomData } from '@/hooks/useGetRoomData';
 import styles from './page.module.css';
-import { useEffect } from 'react';
-import { useRoomUserDataStore } from '@/store/placeStore';
-import { insertRoomUser } from '@/api/room';
 
 const RoomPage = ({ params }: { params: { id: string } }) => {
-  const { userId } = useGetRoomData(params.id);
-  const roomUsers = useRoomUserDataStore((state) => state.roomUsers);
-
-  useEffect(() => {
-    const joinNewUser = async () => {
-      if (userId && !roomUsers.find((user) => user.user_id === userId)) {
-        await insertRoomUser({ room_id: params.id, user_id: userId, is_admin: false });
-      }
-    };
-    joinNewUser();
-  }, [params.id, userId]);
-
   return (
     <main className={styles.main}>
       <Sidebar />

--- a/src/components/room/StartMeeting.tsx
+++ b/src/components/room/StartMeeting.tsx
@@ -2,6 +2,7 @@
 
 import { insertNewRoom, insertRoomUser } from '@/api/room';
 import { useQueryUser } from '@/hooks/useQueryUser';
+import { getCurrentFormattedDate } from '@/utils/getCurrentFormattedDate';
 import { useRouter } from 'next/navigation';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
@@ -9,7 +10,7 @@ const StartMeeting = () => {
   const router = useRouter();
   const user = useQueryUser();
 
-  const [startDate, setStartDate] = useState(new Date().toDateString());
+  const [startDate, setStartDate] = useState(getCurrentFormattedDate());
 
   const changeDate = (e: ChangeEvent<HTMLInputElement>) => {
     setStartDate(e.target.value);
@@ -36,8 +37,8 @@ const StartMeeting = () => {
   return (
     <form onSubmit={startNewRoom}>
       <div className="flex w-full flex-wrap md:flex-nowrap gap-4">
-        <input type="date" name="start" value={startDate} onChange={changeDate} />
-        <input type="date" min={startDate} name="end" />
+        <input type="date" name="start" min={startDate} value={startDate} onChange={changeDate} />
+        <input type="date" name="end" min={startDate} />
       </div>
       <button>모임 시작하기</button>
     </form>

--- a/src/components/room/sidebar/user/UserList.tsx
+++ b/src/components/room/sidebar/user/UserList.tsx
@@ -1,8 +1,27 @@
 'use client';
-import { useRoomUserDataStore } from '@/store/placeStore';
+import { insertRoomUser } from '@/api/room';
+import { useGetRoomData } from '@/hooks/useGetRoomData';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 const UserList = () => {
-  const roomUsers = useRoomUserDataStore((state) => state.roomUsers);
+  const user = useQueryUser();
+  const { id: roomId }: { id: string } = useParams();
+  const { roomUsers, isLoading } = useGetRoomData(roomId, user.id);
+
+  useEffect(() => {
+    const joinNewUser = async () => {
+      const isNewUser = !roomUsers.some((user) => user.user_id === user.id);
+      if (isNewUser) return;
+      await insertRoomUser({ room_id: roomId, user_id: user.id, is_admin: false });
+    };
+
+    if (!isLoading && roomUsers.length > 0) {
+      joinNewUser();
+    }
+  }, [roomUsers]);
+
   return (
     <section>
       <ul>

--- a/src/hooks/useGetCalendar.ts
+++ b/src/hooks/useGetCalendar.ts
@@ -21,7 +21,7 @@ export const useGetCalendar = (id: string | null) => {
 
   useEffect(() => {
     const subscription = supabase
-      .channel('room')
+      .channel('schedule')
       .on(
         'postgres_changes',
         { event: '*', schema: 'public', table: 'room_schedule', filter: `room_id=eq.${id}` },

--- a/src/utils/getCurrentFormattedDate.ts
+++ b/src/utils/getCurrentFormattedDate.ts
@@ -1,0 +1,9 @@
+// 2024-04-13
+export const getCurrentFormattedDate = () => {
+  const currentDate = new Date();
+  const year = currentDate.getFullYear();
+  const month = (currentDate.getMonth() + 1).toString().padStart(2, '0');
+  const day = currentDate.getDate().toString().padStart(2, '0');
+
+  return year + '-' + month + '-' + day;
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- closed #141
- #67
- #107

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] #141
- [x] 채널이름 같아서 실시간 구독 안되는 문제 수정
- [x] 모임 생성 페이지에서 시작일자 오늘 이전에는 선택못하게 만듦

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```typescript
await queryClient.prefetchQuery<User | null>({
  queryKey: ['auth'],
  queryFn: getSession,
  gcTime: Infinity
});
```
gcTime 무한으로 주는 옵션있다. 

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
- gcTime이 지나면 유저정보를 가져오지 못해 프로필에서 에러가 뜨는 것 -> 유저정보 가져오는 prefetchQuery gcTime무한으로 만듦 
- supabase 채널 실시간 구독 쿼리키가 같아서 구독이 안되던 문제 -> 각각 다른 채널이름으로 설정
## 📸 스크린샷(선택)
![image](https://github.com/where-we-meet/owl/assets/85791020/c12be965-51b6-4c39-983a-8e92e9b0d260)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- [실시간 채널 이름 중복 문제](https://www.reddit.com/r/Supabase/comments/16n33n9/realtime_subscriptions_to_multiple_tables/)
- [gcTime 알고싶은사람](https://velog.io/@tykim1227/react-query-%ED%8C%8C%EB%B3%B4%EA%B8%B0-%EC%BA%90%EC%8B%B1-%EB%9D%BC%EC%9D%B4%ED%94%84%EC%82%AC%EC%9D%B4%ED%81%B4)

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
- 마이페이지