### PR TITLE
[fix/setting-schedule] 일정 설정 페이지 기존 선택한 날짜 초기화 버튼 생성, room_schedule 테이블 realtime event -> insert, delete 분리, 날짜 선택 가능 범위 버그 수정

### DIFF
--- a/src/api/room.ts
+++ b/src/api/room.ts
@@ -30,10 +30,8 @@ export const insertRoomUser = async ({
   const { data, error: insertUserError } = await supabase
     .from('userdata_room')
     .insert([{ room_id, user_id, is_admin }]);
-  const { error: insertScheduleError } = await supabase
-    .from('room_schedule')
-    .insert([{ room_id, created_by: user_id }]);
+
   if (insertUserError) throw insertUserError;
-  if (insertScheduleError) throw insertScheduleError;
+
   return data;
 };

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -116,6 +116,10 @@ export const upsertSchedule = async (payload: UpsertUserSchedule[]) => {
   const { data, error } = await supabase.from('room_schedule').upsert(payload);
 };
 
+export const deleteSchedule = async (payload: { roomId: string; userId: string }) => {
+  await supabase.from('room_schedule').delete().eq('room_id', payload.roomId).eq('created_by', payload.userId);
+};
+
 // 모임 시작하기 페이지에서 설정한 일정 선택 범위 가져오는 로직
 export const getRangeOfSchedule = async (id: string) => {
   const { data, error } = await supabase.from('rooms').select('start_date, end_date').eq('id', id);

--- a/src/app/room/[id]/(setting)/confirm/page.tsx
+++ b/src/app/room/[id]/(setting)/confirm/page.tsx
@@ -8,6 +8,7 @@ import { useCalendarStore } from '@/store/calendarStore';
 import { useSearchDataStore } from '@/store/placeStore';
 import { sortDate } from '@/utils/sortDate';
 import { Button } from '@nextui-org/react';
+import { createClient } from '@/utils/supabase/client';
 
 const SettingConfirmPage = () => {
   const { mutate, isSuccess } = useMutateUserData();
@@ -60,6 +61,7 @@ const SettingConfirmPage = () => {
         <div key={index}>{new Date(date).toLocaleDateString()}</div>
       ))}
       <div>{address}</div>
+
       <Button onClick={handlePrevStep}>이전</Button>
       <Button onClick={handleSubmit}>저장</Button>
     </>

--- a/src/app/room/[id]/(setting)/pick-calendar/page.tsx
+++ b/src/app/room/[id]/(setting)/pick-calendar/page.tsx
@@ -1,7 +1,25 @@
+'use client';
+
 import Calender from '@/components/room/meeting/calender/Calender';
+import ResetSchedule from '@/components/room/meeting/calender/ResetSchedule';
+import { useCalendarStore } from '@/store/calendarStore';
+import checkSelectedDates from '@/utils/calendar/checkSelectedDates';
+import { Button, Link } from '@nextui-org/react';
+import { useParams } from 'next/navigation';
 
 const PickCalendar = () => {
-  return <Calender />;
+  const { id } = useParams();
+  const selectedDates = useCalendarStore((state) => state.selectedDates);
+
+  return (
+    <>
+      <ResetSchedule />
+      <Calender />
+      <Button href={`/room/${id}/pick-place`} size="sm" disabled={!checkSelectedDates(selectedDates)} as={Link}>
+        다음
+      </Button>
+    </>
+  );
 };
 
 export default PickCalendar;

--- a/src/components/room/meeting/calender/Calender.tsx
+++ b/src/components/room/meeting/calender/Calender.tsx
@@ -5,14 +5,11 @@ import { format, subMonths, addMonths, isSameDay, isWithinInterval } from 'date-
 
 import styles from './Calender.module.css';
 import EntireOfMonth from './EntireOfMonth';
-import checkSelectedDates from './checkSelectedDates';
 
 import { useCalendarStore } from '@/store/calendarStore';
 import { useGetCalendar } from '@/hooks/useGetCalendar';
 
 import { useParams } from 'next/navigation';
-import { Button } from '@nextui-org/react';
-import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { getRangeOfSchedule } from '@/api/supabaseCSR/supabase';
 
@@ -46,8 +43,9 @@ const Calender = () => {
     const isAlreadySelected = selectedDates.some((selected) => isSameDay(selected, date));
 
     if (!data?.start_date || !data?.end_date) return;
-
-    if (!isWithinInterval(date, { start: new Date(data.start_date), end: new Date(data.end_date) })) {
+    const startDate = new Date(data.start_date);
+    const endDate = new Date(data.end_date);
+    if (!isWithinInterval(date, { start: startDate.setDate(startDate.getDate() - 1), end: endDate })) {
       return;
     }
 
@@ -58,13 +56,6 @@ const Calender = () => {
       const newDateList = [...selectedDates, date];
       setSelectedDates(newDateList);
     }
-  };
-
-  const handleDateUpload = (date: Date) => {
-    if (!checkSelectedDates(selectedDates)) return;
-
-    const newDateList = [...selectedDates, date];
-    setSelectedDates(newDateList);
   };
 
   return (
@@ -98,17 +89,6 @@ const Calender = () => {
               id={id}
             />
           </div>
-        </div>
-
-        <div>
-          <Button
-            size="sm"
-            className={styles.next_button}
-            onClick={() => handleDateUpload}
-            disabled={!checkSelectedDates(selectedDates)}
-          >
-            <Link href={`/room/${id}/pick-place`}>다음</Link>
-          </Button>
         </div>
       </div>
     </>

--- a/src/components/room/meeting/calender/ResetSchedule.tsx
+++ b/src/components/room/meeting/calender/ResetSchedule.tsx
@@ -1,0 +1,19 @@
+import { useDeleteUserSchedule } from '@/hooks/useMutateUserData';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { useParams } from 'next/navigation';
+import { LuEraser } from 'react-icons/lu';
+
+const ResetSchedule = () => {
+  const { id: roomId }: { id: string } = useParams();
+  const { id: userId } = useQueryUser();
+
+  const { mutate, isSuccess } = useDeleteUserSchedule();
+
+  const handleResetSchedule = () => {
+    mutate({ roomId, userId });
+  };
+
+  return <LuEraser style={{ cursor: 'pointer' }} onClick={handleResetSchedule} />;
+};
+
+export default ResetSchedule;

--- a/src/hooks/useMutateUserData.ts
+++ b/src/hooks/useMutateUserData.ts
@@ -1,4 +1,4 @@
-import { upsertSchedule, updateStartLocation } from '@/api/supabaseCSR/supabase';
+import { upsertSchedule, updateStartLocation, deleteSchedule } from '@/api/supabaseCSR/supabase';
 import { UserLocationData } from '@/types/place.types';
 import { UpsertUserSchedule } from '@/types/roomUser';
 import { useMutation } from '@tanstack/react-query';
@@ -13,6 +13,15 @@ export const useMutateUserData = () => {
     mutationFn: async (payload: Payload) => {
       const updateLocationResponse = await updateStartLocation(payload.userLocationData);
       const updateCalendarResponse = await upsertSchedule(payload.userSchedules);
+    }
+  });
+  return { mutate, isSuccess };
+};
+
+export const useDeleteUserSchedule = () => {
+  const { mutate, isSuccess } = useMutation({
+    mutationFn: async (payload: { roomId: string; userId: string }) => {
+      await deleteSchedule(payload);
     }
   });
   return { mutate, isSuccess };


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 일정 설정 페이지 기존 선택한 날짜 초기화 버튼 생성
- [ ] realtime event -> insert, delete 분리
- [ ] 날짜 선택 가능 범위 버그 수정

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
일정 설정 페이지 기존 선택한 날짜 초기화 버튼 생성
room_schedule 테이블 realtime event -> insert, delete 분리
날짜 선택 가능 범위 버그 수정
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
