### PR TITLE
[fix/range marker] 반경 변경시 카테고리 검색 결과 Marker가 유지되는 버그 수정

### DIFF
--- a/src/components/room/meeting/place/search/CategorySelector.tsx
+++ b/src/components/room/meeting/place/search/CategorySelector.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent } from 'react';
+import { useEffect } from 'react';
 import { useHalfwayDataStore, useRangeStore, useSearchDataStore } from '@/store/placeStore';
 import { IoCafe, IoRestaurant } from 'react-icons/io5';
 import { FaTrainSubway, FaLandmark } from 'react-icons/fa6';
@@ -18,7 +18,7 @@ const SEARCH_CATEGORY = [
 
 const CategorySelector = () => {
   const searchOption = useSearchDataStore((state) => state.searchOption);
-  const setSearchOption = useSearchDataStore((state) => state.setSearchOption);
+  const { setSearchOption, updateSearchRange } = useSearchDataStore((state) => state);
   const { lat, lng } = useHalfwayDataStore((state) => state);
   const range = useRangeStore((state) => state.range);
 
@@ -31,6 +31,10 @@ const CategorySelector = () => {
     };
     setSearchOption(newSearchOption);
   };
+
+  useEffect(() => {
+    updateSearchRange(range);
+  }, [range]);
 
   return (
     <ul className={styles.category}>

--- a/src/store/placeStore.ts
+++ b/src/store/placeStore.ts
@@ -15,6 +15,7 @@ type SearchData = {
   setLocation: (location: SearchData['location']) => void;
   setAddress: (address: SearchData['address']) => void;
   setSearchOption: (payload: SearchOptionData) => void;
+  updateSearchRange: (payload: number) => void;
 };
 
 type HalfwayData = {
@@ -47,7 +48,7 @@ type Range = {
 
 export const useSearchDataStore = create(
   persist<SearchData>(
-    (set) => ({
+    (set, get) => ({
       location: {
         lat: 33.450701,
         lng: 126.570667
@@ -57,7 +58,8 @@ export const useSearchDataStore = create(
       searchOption: null,
       setLocation: (location) => set({ location }),
       setAddress: (address) => set({ address }),
-      setSearchOption: (payload: SearchOptionData) => set({ searchOption: payload })
+      setSearchOption: (payload) => set({ searchOption: payload }),
+      updateSearchRange: (payload) => set(() => ({ searchOption: { ...get().searchOption, radius: payload } }))
     }),
     {
       name: 'setting-location-storage',

--- a/src/types/place.types.ts
+++ b/src/types/place.types.ts
@@ -26,8 +26,8 @@ export type Halfway = {
 };
 
 export type SearchOptionData = {
-  query: string;
-  x: string;
-  y: string;
+  query?: string | null | undefined;
+  x?: string;
+  y?: string;
   radius: number | null;
 } | null;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
 closed #188 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 반경 변경시 바뀐 반경으로 검색 다시 하기
- [ ] 변경된 데이터 Map에 Marker로 반영

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
range-controller 에서 range가 번경될때 마다 전역으로 관리하는 searchOption 상태의 radius를 최신 range로 update 해준다.
searchOption 상태가 변경되면 keyword search  Query가 실행 !
새로운 반경의 검색 결과 반영!
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
![owl-rang변경시 pin 안 변경 버그](https://github.com/where-we-meet/owl/assets/100992153/778076e9-0623-4b81-86c0-339bfcb6ff72)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
