### PR TITLE
[feat] 유저캘린더에서 데이터를 받아오는 형식을 data, mydata, anotherUserData 로 분류

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -7,11 +7,33 @@ import type { UpsertUserSchedule } from '@/types/roomUser';
 const supabase = createClient();
 
 // supabase에서 roomId를 통해 해당 room 일정과 관련된 모든 Data 반환
-export const getUserSchedule = async (id: string) => {
-  const { data, error } = await supabase.from('room_schedule').select('*').eq('room_id', id);
+export const getUserSchedule = async (roomId: string) => {
+  const { data, error } = await supabase.from('room_schedule').select('*').eq('room_id', roomId);
   if (error) throw error;
   return data;
 };
+
+// //supabase에서 roomId와 userId를 통해 내가 선택한 날짜를 반환
+// export const getMySchedule = async (userId: string, roomId: string) => {
+//   const { data, error } = await supabase
+//     .from('room_schedule')
+//     .select('*')
+//     .eq('room_id', roomId)
+//     .eq('created_by', userId);
+//   if (error) throw error;
+//   return data;
+// };
+
+// //supabase에서 roomId와 userId를 통해 내가 아닌 다른 유저들의 날짜를 반환
+// export const getAnotherUsersSchedule = async (userId: string, roomId: string) => {
+//   const { data, error } = await supabase
+//     .from('room_schedule')
+//     .select('*')
+//     .eq('room_id', roomId)
+//     .neq('created_by', userId);
+//   if (error) throw error;
+//   return data;
+// };
 
 export const getRooomData = async (roomId: string) => {
   const { data, error } = await supabase.from('rooms').select('*').eq('id', roomId);

--- a/src/app/room/[id]/(setting)/pick-calendar/page.tsx
+++ b/src/app/room/[id]/(setting)/pick-calendar/page.tsx
@@ -9,7 +9,7 @@ import { useParams } from 'next/navigation';
 import styles from './page.module.css';
 
 const PickCalendar = () => {
-  const { id } = useParams();
+  const { id }: { id: string } = useParams();
   const selectedDates = useCalendarStore((state) => state.selectedDates);
 
   return (

--- a/src/components/room/meeting/calender/Calender.tsx
+++ b/src/components/room/meeting/calender/Calender.tsx
@@ -17,7 +17,8 @@ import ResetSchedule from './ResetSchedule';
 const WEEKDAYS = ['일', '월', '화', '수', '목', '금', '토'];
 
 const Calender = () => {
-  const { id }: { id: string } = useParams();
+  const { id }: { id: string; } = useParams();
+  
 
   const [nowDate, setNowDate] = useState<Date>(new Date());
   const { selectedDates, setSelectedDates } = useCalendarStore();

--- a/src/hooks/useGetCalendar.ts
+++ b/src/hooks/useGetCalendar.ts
@@ -3,11 +3,11 @@ import { Tables } from '@/types/supabase';
 import { createClient } from '@/utils/supabase/client';
 import { useEffect, useState } from 'react';
 
-type UserSchedule = Tables<'room_schedule'>;
+export type UserSchedule = Tables<'room_schedule'>;
 
 export const useGetCalendar = (roomId: string) => {
-  const [userSchedules, setUserSchedules] = useState<UserSchedule[]>([]);
   const supabase = createClient();
+  const [userSchedules, setUserSchedules] = useState<UserSchedule[]>([]);
 
   useEffect(() => {
     const dateOfUser = async () => {

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -1,0 +1,16 @@
+import { getUserSchedule } from '@/api/supabaseCSR/supabase';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+
+export const useGetSchedule = (userId: string, roomId: string) => {
+  const queryClient = useQueryClient();
+
+  const { data = [] } = useQuery({
+    queryKey: ['getUserSchedules', roomId],
+    queryFn: () => getUserSchedule(roomId),
+    enabled: !!roomId
+  });
+  const myData = data.filter((user) => user.created_by === userId);
+  const anotherUserData = data.filter((user) => user.created_by !== userId);
+
+  return { data, myData, anotherUserData };
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #190

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] room_schedule 테이블의 데이터 가져오는 방식을 클라이언트에서 세분화 합니다.
- [x] 로직을 커스텀 훅으로 분리합니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
기존 데이터를 받아오는 방식은 모든 유저의 스케줄을 한 번에 받아오는 구조였습니다.
이 구조를 커스텀 훅으로 분리하여, 모든 데이터, 나의 데이터, 나 이외 인원의 데이터로 필터하는 방식을 훅으로 제작하였습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. 리액트 쿼리를 사용하면서, 쿼리키에 대한 이해도가 부족한 부분이 존재했음
- 팀원의 설명을 통해 쿼리 키안에 캐싱데이터를 위한 매개변수를 받아오는 것을 이해하게 되었음
```
## 📸 스크린샷(선택)
![image](https://github.com/where-we-meet/owl/assets/109938441/36ad05f6-adc4-4cf8-a8de-405dc47f4c44)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
