### PR TITLE
[feat/pin-overlay] 카테고리 marker info card 보여주기 토글 기능, halfwayPoint 에서 start_location이 없을 때 NaN이 안뜨게 조건 로직 수정

### DIFF
--- a/src/components/room/meeting/place/ResultMap.tsx
+++ b/src/components/room/meeting/place/ResultMap.tsx
@@ -1,19 +1,22 @@
-import { Circle, Map, MapMarker } from 'react-kakao-maps-sdk';
+import { useParams } from 'next/navigation';
+
+import { Circle, Map } from 'react-kakao-maps-sdk';
 import { useKakaoMap } from '@/hooks/useKakaoMap';
 import { useMapController } from '@/hooks/useMapController';
 
 import UserMarker from './UserMarker';
 import Halfway from './Halfway';
-import styles from './ResultMap.module.css';
-import { useParams } from 'next/navigation';
-import { Link } from '@nextui-org/react';
 import CategorySelector from './search/CategorySelector';
 import RangeController from './RangeController';
+import CategoryMarker from './search/CategoryMarker';
+
+import { Link } from '@nextui-org/react';
+import styles from './ResultMap.module.css';
 
 const ResultMap = () => {
   const [loading, error] = useKakaoMap();
   const { id: roomId } = useParams();
-  const { address, halfwayPoint, range, roomUsers, searchCategory = [] } = useMapController();
+  const { address, halfwayPoint, range, clickId, setClickId, roomUsers, searchCategory = [] } = useMapController();
 
   const isHalfwayValid = halfwayPoint.lat && halfwayPoint.lng;
 
@@ -25,14 +28,19 @@ const ResultMap = () => {
       <div className={styles.map_container}>
         {isHalfwayValid && (
           <>
-            <Map center={halfwayPoint} className={styles.map}>
+            <Map
+              center={halfwayPoint}
+              className={styles.map}
+              onClick={() => setClickId('')}
+              onTouchEnd={() => setClickId('')}
+            >
               {roomUsers
                 .filter(({ lat, lng }) => lat !== null && lng !== null)
                 .map(({ id, lat, lng }) => (
                   <UserMarker key={id} id={id} lat={lat as string} lng={lng as string} />
                 ))}
-              {searchCategory.map(({ x, y }, i) => (
-                <MapMarker key={i} position={{ lat: +y, lng: +x }} />
+              {searchCategory.map((info) => (
+                <CategoryMarker key={info.id} info={info} clickId={clickId} setClickId={setClickId} />
               ))}
               <>
                 <Halfway location={halfwayPoint} />

--- a/src/components/room/meeting/place/search/CategoryMarker.module.css
+++ b/src/components/room/meeting/place/search/CategoryMarker.module.css
@@ -1,0 +1,25 @@
+.card {
+  max-width: 400px;
+}
+
+.card_header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.card_header_content {
+  display: flex;
+  flex-direction: column;
+}
+
+.card_body_content {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.small_text {
+  font-size: small;
+  color: gray;
+}

--- a/src/components/room/meeting/place/search/CategoryMarker.tsx
+++ b/src/components/room/meeting/place/search/CategoryMarker.tsx
@@ -1,0 +1,65 @@
+import { type Dispatch, type SetStateAction, useState, useEffect } from 'react';
+import { Card, CardBody, CardHeader, Divider, Link } from '@nextui-org/react';
+
+import { CustomOverlayMap, MapMarker } from 'react-kakao-maps-sdk';
+
+import { FaMapLocationDot } from 'react-icons/fa6';
+import styles from './CategoryMarker.module.css';
+
+type InfoProps = {
+  info: {
+    [key: string]: string;
+  };
+  clickId: string;
+  setClickId: Dispatch<SetStateAction<string>>;
+};
+
+const CategoryMarker = ({
+  info: { id, x, y, category_group_name, place_name, place_url, road_address_name },
+  clickId,
+  setClickId
+}: InfoProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const handleClickMarker = () => {
+    setClickId(id);
+    setIsOpen((prev) => !prev);
+  };
+
+  useEffect(() => {
+    if (id !== clickId) {
+      setIsOpen(false);
+    }
+  }, [clickId]);
+
+  return (
+    <>
+      <MapMarker position={{ lat: +y, lng: +x }} onClick={handleClickMarker} />
+      {isOpen && (
+        <CustomOverlayMap position={{ lat: +y, lng: +x }} yAnchor={1.4}>
+          <Card className={styles.card}>
+            <CardHeader className={styles.card_header}>
+              <div className={styles.card_header_content}>
+                <p>{place_name}</p>
+                <p className={styles.small_text}>{category_group_name}</p>
+              </div>
+              <Divider orientation="vertical" />
+              <Link isExternal showAnchorIcon href={place_url}>
+                더 많은 정보
+              </Link>
+            </CardHeader>
+            <Divider />
+            <CardBody>
+              <div className={styles.card_body_content}>
+                <FaMapLocationDot />
+                <p>{road_address_name}</p>
+              </div>
+            </CardBody>
+          </Card>
+        </CustomOverlayMap>
+      )}
+    </>
+  );
+};
+
+export default CategoryMarker;

--- a/src/hooks/useMapController.ts
+++ b/src/hooks/useMapController.ts
@@ -11,6 +11,7 @@ export const useMapController = () => {
   const { id: roomId }: { id: string } = useParams();
 
   const [address, setAddress] = useState('');
+  const [clickId, setClickId] = useState('');
 
   const { searchOption } = useSearchDataStore((state) => state);
   const range = useRangeStore((state) => state.range);
@@ -41,6 +42,8 @@ export const useMapController = () => {
     address,
     halfwayPoint,
     roomUsers,
-    searchCategory
+    searchCategory,
+    clickId,
+    setClickId
   };
 };

--- a/src/utils/place/calcHalfwayPoint.ts
+++ b/src/utils/place/calcHalfwayPoint.ts
@@ -4,10 +4,10 @@ import convexHull from '@/utils/place/convexHull';
 import type { RoomUser } from '@/types/roomUser';
 
 export const calcHalfwayPoint = (roomUsers: RoomUser[]) => {
-  if (roomUsers.length === 0) return { lat: null, lng: null };
   const hasLocationUsers = roomUsers
     .filter((user) => !!user.start_location)
     .map((user) => ({ location: { lat: Number(user.lat), lng: Number(user.lng) } }));
+  if (hasLocationUsers.length === 0) return { lat: null, lng: null };
   if (hasLocationUsers.length === 1) {
     return hasLocationUsers[0].location;
   } else {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #196 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] info card 생성
- [x] marker 클릭 시 info card 보여주기
- [x] marker 다시 클릭 하거나 외부를 클릭하면 info card 안보여주기
- [x] 다른 marker 선택시 새로운 info card만 보여주기

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
CategoryMarker에 prop drilling 해주고 있는 id와 클릭 한 id 의 차이의 변화로 info card를 보여주고 안보여준다.

start_location 정보를 가지고 있는 유저가 있을 때 halfwaypoint의 위치값을 {lat: null, lng: null}로 반환해 NaN이 안 뜨게 한다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
![owl-info card](https://github.com/where-we-meet/owl/assets/100992153/80aa8bf1-898d-4396-994b-047ec9357622)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
