### PR TITLE
[fix/calendar]: 일정 수정 시, 세션 스토리지에 저장 후 확정 페이지로 넘어감

### DIFF
--- a/src/app/room/[id]/(setting)/pick-calendar/page.tsx
+++ b/src/app/room/[id]/(setting)/pick-calendar/page.tsx
@@ -9,10 +9,15 @@ import { getRangeOfSchedule } from '@/api/supabaseCSR/supabase';
 import { useGetCalendar } from '@/hooks/useGetCalendar';
 import { Button, Link } from '@nextui-org/react';
 import styles from './page.module.css';
+import { useGetSchedule } from '@/hooks/useGetSchedule';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { useEffect } from 'react';
 
 const PickCalendar = () => {
+  const { id: userId }: { id: string } = useQueryUser();
   const { id: roomId }: { id: string } = useParams();
   const selectedDates = useCalendarStore((state) => state.selectedDates);
+  const setSelectedDates = useCalendarStore((state) => state.setSelectedDates);
 
   const { userSchedules } = useGetCalendar(roomId);
   const { data: scheduleRange, isPending } = useQuery({
@@ -20,6 +25,14 @@ const PickCalendar = () => {
     queryFn: () => getRangeOfSchedule(roomId),
     select: (data) => data[0]
   });
+
+  const { myData: mySchedule } = useGetSchedule(userId, roomId);
+
+  useEffect(() => {
+    if (mySchedule) {
+      setSelectedDates(mySchedule.map((schedule) => new Date(String(schedule.start_date))));
+    }
+  }, [mySchedule.length]);
 
   if (!scheduleRange || isPending) return <>로딩중</>;
 

--- a/src/hooks/useGetSchedule.ts
+++ b/src/hooks/useGetSchedule.ts
@@ -1,9 +1,7 @@
 import { getUserSchedule } from '@/api/supabaseCSR/supabase';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 
 export const useGetSchedule = (userId: string, roomId: string) => {
-  const queryClient = useQueryClient();
-
   const { data = [] } = useQuery({
     queryKey: ['getUserSchedules', roomId],
     queryFn: () => getUserSchedule(roomId),


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 일정 수정할 경우, 수정된 일정을 세션 스토리지에 저장하여 확정 페이지로 갑니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
확정 페이지에서 일정 수정을 위해 pick-calendar 페이지로 넘어오면
내 일정은 파란색,  다른 유저의 일정은 보라색으로 구분하여 보여줍니다.
파란색 원을 다시 클릭 시, 수정된 내 일정이 세션 스토리지에 담깁니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
pick-calendar 페이지를 들어가자마자 내 일정을 selectedDate, 즉 세션스토리지에 담아서
수정이 가능하게 하는 로직을 생각해내지 못해 calendar 페이지 안에서 한참 헤맸습니다...ㅎ

```
## 📸 스크린샷(선택)
<img width="586" alt="image" src="https://github.com/where-we-meet/owl/assets/154496294/1e43e84d-eea9-4e51-853f-d667f9363835">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
supabase의 데이터를 그 안에서 다시 필터링 한 후에 가져와서 사용하는 방법을 알았습니다.

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
