### PR TITLE
[fix/profile modal] 프로필 모달 창 뒤로가기 이슈 해결

### DIFF
--- a/src/components/header/ProfileModal.module.css
+++ b/src/components/header/ProfileModal.module.css
@@ -1,0 +1,20 @@
+.modal {
+  max-width: 90%;
+  min-height: 90%;
+
+  align-self: center;
+  align-items: center;
+  justify-content: center;
+  background-color: rgb(238, 238, 238);
+  display: flex;
+}
+
+.modal > button {
+  scale: 0.5;
+  position: absolute;
+  background-color: transparent;
+}
+
+.modal > button > * {
+  scale: 3.3;
+}

--- a/src/components/header/ProfileModal.tsx
+++ b/src/components/header/ProfileModal.tsx
@@ -1,0 +1,30 @@
+import { Modal, ModalContent } from '@nextui-org/react';
+import UserProfileUpdate from './UserProfileUpdate';
+import UserProfileRead from './UserProfileRead';
+import { useEffect, useState } from 'react';
+
+import styles from './ProfileModal.module.css';
+
+export const ProfileModal = ({ onClose, isOpen }: { onClose: () => void; isOpen: boolean }) => {
+  const [editMode, setEditMode] = useState(false);
+  const handleClose = () => {
+    setEditMode(false);
+    onClose();
+  };
+
+  const toggleEditMode = () => {
+    setEditMode((prev) => !prev);
+  };
+
+  return (
+    <Modal className={styles.modal} backdrop="blur" isOpen={isOpen} onClose={handleClose} hideCloseButton>
+      <ModalContent className={styles.modal_container}>
+        {editMode ? (
+          <UserProfileUpdate toggleEditMode={toggleEditMode} isOpen={isOpen} handleClose={handleClose} />
+        ) : (
+          <UserProfileRead toggleEditMode={toggleEditMode} handleClose={handleClose} isOpen={isOpen} />
+        )}
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/src/components/header/UserProfileButton.module.css
+++ b/src/components/header/UserProfileButton.module.css
@@ -1,24 +1,3 @@
-.modal {
-  max-width: 90%;
-  min-height: 90%;
-
-  align-self: center;
-  align-items: center;
-  justify-content: center;
-  background-color: rgb(238, 238, 238);
-  display: flex;
-}
-
-.modal > button {
-  scale: 0.5;
-  position: absolute;
-  background-color: transparent;
-}
-
-.modal > button > * {
-  scale: 3.3;
-}
-
 .profile {
   border-radius: 50%;
   width: 30px;

--- a/src/components/header/UserProfileButton.tsx
+++ b/src/components/header/UserProfileButton.tsx
@@ -4,11 +4,11 @@ import { Avatar, Modal, ModalContent, useDisclosure } from '@nextui-org/react';
 import { useEffect, useState } from 'react';
 import UserProfileUpdate from './UserProfileUpdate';
 import UserProfileRead from './UserProfileRead';
-import { PiUserSquareDuotone } from 'react-icons/pi';
 
 import styles from './UserProfileButton.module.css';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
+import { usePathname } from 'next/navigation';
 
 const UserProfile = () => {
   const user = useQueryUser();
@@ -23,17 +23,37 @@ const UserProfile = () => {
     };
     fetchData();
   }, []);
+
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [editMode, setEditMode] = useState(false);
   const [profile, setProfile] = useState<string | null>('');
-
+  const pathname = usePathname();
+  console.log(pathname);
   const handleClose = () => {
     setEditMode(false);
+    history.back();
     onClose();
   };
 
   const toggleEditMode = () => {
     setEditMode((prev) => !prev);
+  };
+  // window.addEventListener(
+  //   'popstate',
+  //   function (event) {
+  //     //4 or 8번이나 뜸. 왜?
+  //     alert('뒤로가기 버튼이 클릭되었습니다!');
+  //     handleClose();
+  //   },
+  //   { once: true }
+  // );
+  window.onpopstate = () => {
+    alert('뒤로가기 버튼이 클릭되었습니다!');
+    handleClose();
+  };
+  const handleModalOpen = () => {
+    history.pushState(null, '내 프로필', pathname === '/' ? 'profile' : `${pathname}/profile`);
+    onOpen();
   };
 
   return (
@@ -41,7 +61,7 @@ const UserProfile = () => {
       <div className="flex gap-4 items-center" title="내 프로필 설정 및 보기">
         <Avatar
           className={styles.profile}
-          onClick={onOpen}
+          onClick={handleModalOpen}
           showFallback
           name={user.user_metadata.user_name}
           isBordered={true}

--- a/src/components/header/UserProfileButton.tsx
+++ b/src/components/header/UserProfileButton.tsx
@@ -1,18 +1,14 @@
 'use client';
 
-import { Avatar, Modal, ModalContent, useDisclosure } from '@nextui-org/react';
+import { Avatar, useDisclosure } from '@nextui-org/react';
 import { useEffect, useState } from 'react';
-import UserProfileUpdate from './UserProfileUpdate';
-import UserProfileRead from './UserProfileRead';
 
 import styles from './UserProfileButton.module.css';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
-import { usePathname, useRouter } from 'next/navigation';
-import path from 'path';
+import { ProfileModal } from './ProfileModal';
 
 const UserProfile = () => {
-  console.log('hi');
   const user = useQueryUser();
   useEffect(() => {
     const fetchData = async () => {
@@ -27,38 +23,10 @@ const UserProfile = () => {
   }, []);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [editMode, setEditMode] = useState(false);
-  const [profile, setProfile] = useState<string | null>('');
-  const pathname = usePathname();
-  const router = useRouter();
-  const handleClose = () => {
-    setEditMode(false);
-    history.back();
-    onClose();
-  };
 
-  const toggleEditMode = () => {
-    setEditMode((prev) => !prev);
-  };
-  // window.addEventListener(
-  //   'popstate',
-  //   function (event) {
-  //     //4 or 8번이나 뜸. 왜?
-  //     alert('뒤로가기 버튼이 클릭되었습니다!');
-  //     handleClose();
-  //   },
-  //   { once: true }
-  // );
-  if (!isOpen) {
-    window.onpopstate = () => {
-      alert('뒤로가기 버튼이 클릭되었습니다!');
-      handleClose();
-      router.replace(pathname);
-    };
-  }
+  const [profile, setProfile] = useState<string | null>('');
 
   const handleModalOpen = () => {
-    history.pushState(null, '내 프로필', pathname === '/' ? 'profile' : `${pathname}/profile`);
     onOpen();
   };
 
@@ -74,16 +42,7 @@ const UserProfile = () => {
           src={`${profile}`}
         />
       </div>
-
-      <Modal className={styles.modal} backdrop="blur" isOpen={isOpen} onClose={handleClose} hideCloseButton>
-        <ModalContent className={styles.modal_container}>
-          {editMode ? (
-            <UserProfileUpdate toggleEditMode={toggleEditMode} />
-          ) : (
-            <UserProfileRead toggleEditMode={toggleEditMode} handleClose={handleClose} />
-          )}
-        </ModalContent>
-      </Modal>
+      <ProfileModal onClose={onClose} isOpen={isOpen} />
     </>
   );
 };

--- a/src/components/header/UserProfileButton.tsx
+++ b/src/components/header/UserProfileButton.tsx
@@ -8,9 +8,11 @@ import UserProfileRead from './UserProfileRead';
 import styles from './UserProfileButton.module.css';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
+import path from 'path';
 
 const UserProfile = () => {
+  console.log('hi');
   const user = useQueryUser();
   useEffect(() => {
     const fetchData = async () => {
@@ -28,7 +30,7 @@ const UserProfile = () => {
   const [editMode, setEditMode] = useState(false);
   const [profile, setProfile] = useState<string | null>('');
   const pathname = usePathname();
-  console.log(pathname);
+  const router = useRouter();
   const handleClose = () => {
     setEditMode(false);
     history.back();
@@ -47,10 +49,14 @@ const UserProfile = () => {
   //   },
   //   { once: true }
   // );
-  window.onpopstate = () => {
-    alert('뒤로가기 버튼이 클릭되었습니다!');
-    handleClose();
-  };
+  if (!isOpen) {
+    window.onpopstate = () => {
+      alert('뒤로가기 버튼이 클릭되었습니다!');
+      handleClose();
+      router.replace(pathname);
+    };
+  }
+
   const handleModalOpen = () => {
     history.pushState(null, '내 프로필', pathname === '/' ? 'profile' : `${pathname}/profile`);
     onOpen();

--- a/src/components/header/UserProfileRead.tsx
+++ b/src/components/header/UserProfileRead.tsx
@@ -12,9 +12,16 @@ import Logout from '../auth/LogoutButton';
 
 export type UserProfileData = { name: string; profile_url: string | null };
 
-const UserProfileRead = ({ toggleEditMode, handleClose }: { toggleEditMode: () => void; handleClose: () => void }) => {
+const UserProfileRead = ({
+  toggleEditMode,
+  handleClose,
+  isOpen
+}: {
+  toggleEditMode: () => void;
+  handleClose: () => void;
+  isOpen: boolean;
+}) => {
   const user = useQueryUser();
-
   //state for recent profile data (from supabase DB)
   const [data, setData] = useState<UserProfileData>({
     name: '',
@@ -33,7 +40,14 @@ const UserProfileRead = ({ toggleEditMode, handleClose }: { toggleEditMode: () =
     };
     fetchData();
   }, []);
-
+  useEffect(() => {
+    if (isOpen === true) {
+      window.addEventListener('popstate', handleClose);
+    }
+    if (isOpen === false) {
+      window.removeEventListener('popstate', handleClose);
+    }
+  }, [isOpen]);
   return (
     <>
       <Button className={styles.close_btn} isIconOnly onPress={handleClose}>

--- a/src/components/header/UserProfileUpdate.tsx
+++ b/src/components/header/UserProfileUpdate.tsx
@@ -13,7 +13,15 @@ import { AiFillPlusCircle } from 'react-icons/ai';
 import styles from './UserProfileUpdate.module.css';
 const MAX_NAME_LENGTH = 16;
 
-const UserProfileUpdate = ({ toggleEditMode }: { toggleEditMode: () => void }) => {
+const UserProfileUpdate = ({
+  toggleEditMode,
+  isOpen,
+  handleClose
+}: {
+  toggleEditMode: () => void;
+  isOpen: boolean;
+  handleClose: () => void;
+}) => {
   const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
   const [toggleModal, setToggleModal] = useState(false);
@@ -54,6 +62,14 @@ const UserProfileUpdate = ({ toggleEditMode }: { toggleEditMode: () => void }) =
     }
   }, [data]);
 
+  useEffect(() => {
+    if (isOpen === true) {
+      window.addEventListener('popstate', handleClose);
+    }
+    if (isOpen == false) {
+      window.removeEventListener('popstate', handleClose);
+    }
+  }, [isOpen]);
   return (
     <>
       <Button className={styles.back_btn} isIconOnly onPress={toggleEditMode}>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #203 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 뒤로가기 이벤트를 감지하여서, 뒤로가기 버튼을 클릭할 때 모달 창 역시 닫히도록 하였습니다.
- [x] 모달창에서만 해당 이벤트가 작동할 수 있도록 모달에 대한 컴포넌트 분리를 진행했습니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
`UserProfileRead.tsx`, `UserProfileUpdate.tsx` 컴포넌트 내부에 각각 `isOpen`을 구독하는 `useEffect`문을 만들고, 해당 훅의 콜백함수로 이벤트 리스너 등록 및 전처리(모달 닫기)를 해주었습니다.
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
0. 브라우저에서 라우팅 하는 방식을 공부한 후,  parallel route, route intercept등의 개념을 채택하여 모달의 기능을 구현하고자 했습니다. 
- 모달이 열려있을 때 앞으로가기/뒤로가기 버튼을 누르면 모달 안에서만의 라우팅이 되도록 한다.
- 프로필 조회 화면에서의 뒤로가기는 단순히 모달을 끄는 동작만 한다.
의 목적을 달성 하기에는 위 개념이 가장 적합하다 판단했기 때문입니다. 그러나 시도 중 몇가지의 한계가 존재하여 해당 방법으로의 구현을 포기하게 되었습니다.
```
1. 적용하고자 하는 모달은 페이지가 아닌 컴포넌트이다. 따라서 parallel router를 적용하려면 헤더를 페이지 형태로 전부 옮겨야 하는 대대적인 작업이 필요하다. 비용이 크다.
2. 적용하고자 하는 모달은 헤더 레이아웃으로 잡혀 있기에, route intercept를 하기 위해 헤더를 어찌 저찌 페이지 형태로 옮긴다고 한들 intercept해야 하는 경로의 수가 굉장히 많았다. (id에 대해서는 똑같이 동적으로 해주면 되지만, 각 과정에 대한 페이지 경로가 다양했다.) 
따라서 비효율적인 과정이라 판단했다.
```
2. 히스토리 스택의 특성을 이용해 모달 창이 띄워졌을 때 하나의 히스토리를 쌓는 방식을 채택하고자 했습니다. 모달 내에서 이동할 때는 replace로 주소의 이름을 바꿔주고, 모달을 나가는 모든 이벤트 (뒤로가기, close)가 작동할 때는 해당 히스토리가 아예 삭제될 수 있도록 구현하고자 했습니다. 그러나 이 역시 구현 후 테스트 과정에서 이슈를 발견해 방향을 틀게 되었습니다.
```
1. 히스토리가 아예 삭제되지 않으면, 앞으로 가기 버튼이 활성화되는 문제가 있었습니다.
: 이 경우, 해당 경로는 실제로 페이지의 주소가 아닌 모달을 위한 가상 주소이므로 라우팅에 에러가 발생합니다.
2. 웹에서 히스토리를 아예 삭제하는 것이 불가능합니다.
: 이로 인해 위 전략을 포기하게 되었습니다.
```
3. 테스트를 위해 이벤트를 원하는 경우에만 alert창을 띄우는 로직을 만들었는데, 모든 뒤로가기 이벤트에서 해당 alert 창이 띄워지는 문제가 있었습니다.
```
window.onpopstate를 사용하여 이벤트를 다루었었는데, 
1. 해당 이벤트가 열리는 경우를 조건문으로 분리해주지 않았음.
2. 위 기능은 애초에 addEventListener 형태가 아닌 onpopstate 액션 자체가 일어날 때 콜백 함수를 실행해주므로 조건문으로 분기해도 문제가 해결되지 않았었음.
3. 따라서 프로필 버튼과 모달 컴포넌트를 분리하고, 모달 컴포넌트 내의 각 Read, Update 컴포넌트에서 개별적으로 useEffect 하여 모달의 onOpen 상태를 의존성 배열로 감지하도록 했습니다. 
:  useEffect의 콜백함수에는 onOpen인 경우에 popstate 이벤트 리스너를 등록하여 모달을 닫도록 해주었고, onClose인 경우에 onpopstate 이벤트 리스너 구독을 해제하도록 구현하였습니다.
```
4.  결론적으로는 위의 과정을 반복하며 웹적인 라우팅과 앱적인 라우팅의 차이가 굉장히 큼을 인지할 수 있었고, 웹 브라우저 자체 특성을 인정하여 앱 형태의 라우팅을 포기하였습니다.
5. 전반적으로 라우팅에 대한 자유도가 높지 않음을 많이 느꼈습니다. 웹애서 앱의 사용성을 느끼게 하고 싶었는데, 많이 아쉽습니다.
6. 모바일 앱에서의 UX와 웹에서의 UX에는 차이가 있을 수 밖에 없는 이유를 routing을 다루어보며 확실히 깨달았습니다. 
7. 실제 문제 해결까지 필요한 코드는 몇 줄 되지 않았지만, 그 과정이 매우 힘들었습니다. 모달 자체가 모바일앱스러운 UI라는 것과, 플랫폼의 한계를 제대로 인지하는 데 오랜 시간이 걸린 것 같네요. 그래도 좋은 고민과 싸움의 시간이었다고 생각합니다.

<image src="https://github.com/where-we-meet/owl/assets/69431340/446a8740-4db2-4876-ab26-cf9802578402" width=200/>
<image src="https://github.com/where-we-meet/owl/assets/69431340/ffad045f-b565-4ef5-b07f-e869fd8a1607" width=200/>

## 📸 스크린샷(선택)
![화면 기록 2024-04-17 오후 4 40 13](https://github.com/where-we-meet/owl/assets/69431340/1461da87-d912-4629-bedc-f766fb7100fa)


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- [beforePopState : 브라우저의 라우팅](https://careerly.co.kr/qnas/760)
- [Parellel Routes](https://velog.io/@cooljp95/Next.js-Parallel-Routes)
- [Intercepting Route](https://taejinii.tistory.com/m/84)
- [Route로 관리하는 모달 만들기](https://devbirdfeet.tistory.com/346)
- [React 브라우저의 뒤로가기 기본 동작 커스텀하기](https://velog.io/@sumi-0011/React-back-custom)
- [Parellel Route와  Route Intercept를 활용한 모달 구현](https://velog.io/@cooljp95/Next.js-%EB%9D%BC%EC%9A%B0%ED%8C%85%EC%9C%BC%EB%A1%9C-%EB%AA%A8%EB%8B%AC-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)
- [Query를 통한 모달 뒤로가기 처리 방법 : 제가 시도한 history 스택과 비슷한 방법이라고 생각해요. 근데 더 복잡한 것 같아서 건너뜀.](https://blog.toktokhan.dev/mobile-web-react-modal-%EC%97%90%EC%84%9C-%EB%92%A4%EB%A1%9C%EA%B0%80%EA%B8%B0-%EC%B2%98%EB%A6%AC-d0a714858ffa)
- [history.pushState](https://kwangsunny.tistory.com/28)
- [이벤트 한 번만 실행되도록 하기 : 초기에 사용했던 방법인데, useEffect를 써서 대체, 해결했습니다.](https://inpa.tistory.com/entry/JS-%F0%9F%93%9A-%EC%9D%B4%EB%B2%A4%ED%8A%B8-%EC%A0%9C%EA%B1%B0-%ED%95%9C%EB%B2%88%EB%A7%8C-%EC%8B%A4%ED%96%89%EB%90%98%EA%B2%8C-%ED%95%98%EA%B8%B0-removeEventListener-once)
- [자바스크립트 뒤로가기 이벤트 감지 방법 : 비교적(?) 로우레벨(?)에서 동작하는 걸 알고 싶어서 찾아봤는데, 만족하는 수준의 로우레벨이 아니긴 했어요. 그래도 메서드 알아보는 데 도움되었습니다.](https://dirtycoders.net/jabaseukeuribteu-dwirogagi-ibenteu-gamjihagi-yejewa-eungyong/)
- [window is not defined error 원인 찾기 : window객체는 브라우저에 정의되어있는 것이기에, 빌드타임에는 window 전역객체가 존재하지 않는다고 합니다.(빌드타임에는 직접적으로 접근 불가) 어쩌고보면 위에 적혀야 할 트러블 슈팅 중 하나네요.](https://stackoverflow.com/questions/74708606/referenceerror-window-is-not-defined-error-in-nexts)
- [window is not defined error 해결하기](https://dev.to/vvo/how-to-solve-window-is-not-defined-errors-in-react-and-next-js-5f97)
- [useRouter의 기능들](https://velog.io/@henrynoowah/Next.js-v13.-nextnavigation)
- [SPA인 react가 라우팅을 할 수 있는 이유](https://velog.io/@hochul/%EB%A6%AC%EC%95%A1%ED%8A%B8-%EB%9D%BC%EC%9A%B0%ED%84%B0%EB%8A%94-%EC%96%B4%EB%96%BB%EA%B2%8C-%EC%97%86%EB%8A%94-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%A5%BC-%EB%A7%8C%EB%93%A4%EA%B9%8C)
- [nextjs 같은 페이지에서 window history 쌓기](https://kyounghwan01.github.io/blog/React/next/same-page-stack-history/#%E1%84%80%E1%85%A2%E1%84%8B%E1%85%AD)
- [next14에서 페이지 이동 감지하기](https://yunjeoming.dev/blog/detect-page-navigation-in-next14)
-------
### 기타 보면 좋을 자료
- [라이브러리 없이 라우터 만들기 : 라우터를 기본적으로 이해하는 데 도움될 것 같아요. 시간되면 직접 따라해보고 싶습니다.](https://fe-developers.kakaoent.com/2022/221124-router-without-library/)
- 당근마켓에서 웹에서의 스택 네비게이션을 구현하기 위해 자체적으로 stack flow라는 라이브러리를 만들었다는 것을 알게 되었습니다. 다만, 이를 프로젝트에 적용하려면 바꿔야 하는 사항이 많아 적용하지 못했는데 다음에 한 번 해당 라이브러리를 분석해보면 좋을 것 같아요. 히스토리 스택을 복제해서 커스텀 한 것 같습니다.
## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
뭐든 좋습니다. monkey test!!🐒