### PR TITLE
[fix/in app browser] 카카오톡 인앱브라우저에서 구글 로그인 시도 시, 403 에러

### DIFF
--- a/src/app/room/[id]/layout.tsx
+++ b/src/app/room/[id]/layout.tsx
@@ -1,8 +1,38 @@
+'use client';
+
 import RoomHeader from '@/components/room/header/RoomHeader';
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import styles from './layout.module.css';
 
 const RoomLayout = ({ children }: { children: ReactNode }) => {
+  useEffect(() => {
+    const useragt = navigator.userAgent.toLowerCase();
+    const target_url = location.href;
+
+    if (useragt.match(/kakaotalk/i)) {
+      //카카오톡 외부브라우저로 호출
+      window.location.href = 'kakaotalk://web/openExternal?url=' + encodeURIComponent(target_url);
+    } else if (useragt.match(/line/i)) {
+      if (target_url.indexOf('?') !== -1) {
+        window.location.href = target_url + '&openExternalBrowser=1';
+      } else {
+        window.location.href = target_url + '?openExternalBrowser=1';
+      }
+    }
+    if (useragt.match(/iphone|ipad|ipod/i)) {
+      // 아이폰은 강제로 사파리를 실행할 수 없다 ㅠㅠ
+      // 모바일 대응 뷰포트 강제 설정
+      const mobile = document.createElement('meta');
+      mobile.name = 'viewport';
+      mobile.content = 'width=device-width, initial-scale=1, shrink-to-fit=no, user-scalable=no, minimal-ui';
+      document.getElementsByTagName('head')[0].appendChild(mobile);
+    } else {
+      // 안드로이드는 Chrome이 설치되어있음으로 강제로 스킴 실행한다.
+      window.location.href =
+        'intent://' + target_url.replace(/https?:\/\//i, '') + '#Intent;scheme=http;package=com.android.chrome;end';
+    }
+  }, []);
+
   return (
     <main className={styles.main}>
       <RoomHeader />


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#206 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ x ] 카톡 인앱브라우저에서 링크 열기 시도할 때, 외부 브라우저로 호출하는 코드 추가

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
카톡 인앱브라우저에서 링크 열기 시도할 때, 외부 브라우저로 호출하는 코드를 추가했습니다.
카카오톡과 라인 이외의 앱 (ex. 틱톡, 스냅챗) 에서 다른 브라우저를 여는 코드 등의 
불필요한 코드는 제외했습니다. 

```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
<img width="773" alt="image" src="https://github.com/where-we-meet/owl/assets/154496294/8bace480-f0ac-44fa-b5e7-e021926c9275">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
바로 테스트할 길이 없어 맞는 방법으로 코드를 추가한 건지 모르겠습니다ㅜㅜ

재상튜터님께서 알려주신 우회 코드의 홈페이지입니다.
https://burndogfather.com/271?source=post_page-----e6d6a424853--------------------------------

카카오톡/라인 등 인앱브라우저를 사용하는 이유를 처음 알았습니다.
https://brunch.co.kr/@b30afb04c9f54dc/45


## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
dev에서 인앱브라우저 환경에서 제대로 작동하는지 테스트하려 했으나,
방법이 없어 보여서 배포 후 테스트가 필요할 것 같습니다..ㅜ