### PR TITLE
[fix/error] iOS 및 기타 브라우저 최신 문법 적용 이슈 해결

### DIFF
--- a/src/utils/groupBy.ts
+++ b/src/utils/groupBy.ts
@@ -3,7 +3,7 @@ type Items = Array<Item>;
 type CallbackFn = (item: Item) => any;
 type CustomGroupBy = (items: Items, callbackFn: CallbackFn) => object;
 
-export const CustomGroupBy: CustomGroupBy = (items: Items, callbackFn: CallbackFn) => {
+export const customGroupBy: CustomGroupBy = (items: Items, callbackFn: CallbackFn) => {
   return items.reduce((a: any, b: any) => {
     const key = typeof callbackFn === 'function' ? callbackFn(b) : b[callbackFn];
 

--- a/src/utils/groupBy.ts
+++ b/src/utils/groupBy.ts
@@ -1,6 +1,11 @@
-export const groupBy = (values: [], keyFinder: any) => {
-  return values.reduce((a: any, b: any) => {
-    const key = typeof keyFinder === 'function' ? keyFinder(b) : b[keyFinder];
+type Item = any;
+type Items = Array<Item>;
+type CallbackFn = (item: Item) => any;
+type CustomGroupBy = (items: Items, callbackFn: CallbackFn) => object;
+
+export const CustomGroupBy: CustomGroupBy = (items: Items, callbackFn: CallbackFn) => {
+  return items.reduce((a: any, b: any) => {
+    const key = typeof callbackFn === 'function' ? callbackFn(b) : b[callbackFn];
 
     if (!a[key]) {
       a[key] = [b];

--- a/src/utils/groupBy.ts
+++ b/src/utils/groupBy.ts
@@ -1,0 +1,13 @@
+export const groupBy = (values: [], keyFinder: any) => {
+  return values.reduce((a: any, b: any) => {
+    const key = typeof keyFinder === 'function' ? keyFinder(b) : b[keyFinder];
+
+    if (!a[key]) {
+      a[key] = [b];
+    } else {
+      a[key] = [...a[key], b];
+    }
+
+    return a;
+  }, {});
+};

--- a/src/utils/mostSchedule.ts
+++ b/src/utils/mostSchedule.ts
@@ -1,5 +1,7 @@
+import { CustomGroupBy } from './groupBy';
+
 export const mostSchedule = (userSchedules: any) => {
-  const result = Object.groupBy(userSchedules, ({ start_date }: { start_date: string }) => start_date || 'not-setting');
+  const result = CustomGroupBy(userSchedules, ({ start_date }: { start_date: string }) => start_date || 'not-setting');
   const sortResult = Object.entries(result).sort((a, b) => {
     const aLength = a[1] ? a[1].length : 0;
     const bLength = b[1] ? b[1].length : 0;

--- a/src/utils/mostSchedule.ts
+++ b/src/utils/mostSchedule.ts
@@ -1,7 +1,7 @@
-import { CustomGroupBy } from './groupBy';
+import { customGroupBy } from './groupBy';
 
 export const mostSchedule = (userSchedules: any) => {
-  const result = CustomGroupBy(userSchedules, ({ start_date }: { start_date: string }) => start_date || 'not-setting');
+  const result = customGroupBy(userSchedules, ({ start_date }: { start_date: string }) => start_date || 'not-setting');
   const sortResult = Object.entries(result).sort((a, b) => {
     const aLength = a[1] ? a[1].length : 0;
     const bLength = b[1] ? b[1].length : 0;


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #211 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 최신 문법 적용 이슈로 인해 모임 방 생성 및 들어가지지 않는 현상 해결하기

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
Object.groupBy가 새로운 JavaScript 문법이라, Babel에서 컴파일 하는 데 문제가 발생한 것으로 보인다. 아직 최신 문법의 적용이 모든 버전의 브라우저에서는 되지 않는  것 같아 해당 함수를 직접 구현하여 대체하려 한다.

일단, 모바일 브라우저에서의 개발자 모드를 확인해야 한다는 문제가 있었다. 이는 Mac Safari & Xcode simulator의 조합으로 확인하였다.
에러 화면은 아래와 같았다.
<img width="1355" alt="스크린샷 2024-04-15 오후 8 04 15" src="https://github.com/where-we-meet/owl/assets/69431340/a35c64a7-9805-4ee9-9a8f-304fe5574149">
### groupBy를 직접 구현해보자.
1. 우선 함수의 시그니처와 인터페이스를 알아보았다.
  시그니처
  ```
인자로 items와 keySelector 를 받는다. 
이 때, items는 iterable이며 keySelector는 callback함수이다.
  ```
  기존 groupBy에 정의된 인터페이스
  ```typescript
  interface ObjectConstructor {
      /**
       * Groups members of an iterable according to the return value of the passed callback.
       * @param items An iterable.
       * @param keySelector A callback which will be invoked for each item in items.
       */
      groupBy<K extends PropertyKey, T>(
          items: Iterable<T>,
          keySelector: (item: T, index: number) => K,
      ): Partial<Record<K, T[]>>;
  }
  ```
2. 직접 정의하는 함수 타입과 구현체
 customGroupBy 함수의 시그니처는 다음과 같다.
```typescript
type Item = any;
type Items = Array<Item>;
type CallbackFn = (item: Item, index: number) => any;
type CustomGroupBy = (items: Items, callbackFn: CallbackFn) => object;

export const customGroupBy: CustomGroupBy = (items: Items, callbackFn: CallbackFn) => {
  return {};
};
```
groupBy 함수 는 배열과, 해당 배열 속 요소들에게 공통되는 점을 콜백함수를 통해 받아 누적하여 배열로 저장하고, 공통점과 해당 배열을 키-값 쌍으로 정리하여 Object 형태로 반환한다. 따라서 최종적으로 다음과 같이 함수를 작성하였다.
```typescript
type Item = any;
type Items = Array<Item>;
type CallbackFn = (item: Item) => any;
type CustomGroupBy = (items: Items, callbackFn: CallbackFn) => object;

export const customGroupBy: CustomGroupBy = (items: Items, callbackFn: CallbackFn) => {
  return items.reduce((a: any, b: any) => {
    const key = typeof callbackFn === 'function' ? callbackFn(b) : b[callbackFn];

    if (!a[key]) {
      a[key] = [b];
    } else {
      a[key] = [...a[key], b];
    }

    return a;
  }, {});
};

```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
<img width="544" alt="스크린샷 2024-04-17 오후 8 54 31" src="https://github.com/where-we-meet/owl/assets/69431340/cd8d6238-0843-47e3-bff3-2ec5cf374f66"><br/>
개발하며 기록하던 중, 공식 문서에 나와있는 브라우저 별 버전 호환성 정보를 확인하다가 위와 같은 사실을 알게됐다. 직접 구현하는 것보다는 저기에 설명한대로 사용하는 게 더 빠른 에러 해결법일 것 같아 적용해보았지만....<br/>
<img width="544" alt="스크린샷 2024-04-17 오후 8 55 33" src="https://github.com/where-we-meet/owl/assets/69431340/760ef958-0c1c-4f76-8fa9-a3f03b8860b6"><br/>
적용 되지 않는 관계로 다시 customGroupBy 구현으로 넘어왔었다.
 실상 핵심 로직은 거의 외부에서 가져와서, 코드를 더 분석해보면 groupBy 알고리즘의 동작 방식을 자세히 알고 조금 더 이해도 높은 탄탄한 코드를 작성할 수 있을 것 같다.(타입 등)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- [groupBy에 대한 설명](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/groupBy)
- [groupBy에 대한 자세한 설명](https://tc39.es/proposal-array-grouping/#sec-object.groupby)
- [groupToMap에 대한 설명](https://typeoverflow.com/developer/docs/javascript/global_objects/array/grouptomap)
- [reduce](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce)
- [groupBy polyfill](https://learnersbucket.com/examples/interview/groupby-polyfill-in-javascript/#google_vignette)
