### PR TITLE
[fix/searchbar-focus] 검색 결과 list 표시 조건 수정, start와 setting 경로에 따라 첫 지도에 gps 연동 조건 수정

### DIFF
--- a/src/components/room/StartMeeting.tsx
+++ b/src/components/room/StartMeeting.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { getCurrentFormattedDate } from '@/utils/getCurrentFormattedDate';
 import { ChangeEvent, useState } from 'react';
-import { MdStart } from 'react-icons/md';
-import { useCreateRoomStore } from '@/store/createRoomStore';
 import { useRouter } from 'next/navigation';
-import { useCalendarStore } from '@/store/calendarStore';
+import { useCreateRoomStore } from '@/store/createRoomStore';
+import { getCurrentFormattedDate } from '@/utils/getCurrentFormattedDate';
 import { Button, Input } from '@nextui-org/react';
+import { MdStart } from 'react-icons/md';
 import styles from './StartMeeting.module.css';
 
 const StartMeeting = () => {
@@ -14,7 +13,6 @@ const StartMeeting = () => {
   const [startDate, setStartDate] = useState(getCurrentFormattedDate());
   const [endDate, setEndDate] = useState(getCurrentFormattedDate());
   const setDateRange = useCreateRoomStore((state) => state.setDateRange);
-  const setSelectedDates = useCalendarStore((state) => state.setSelectedDates);
 
   const changeStartDate = (e: ChangeEvent<HTMLInputElement>) => {
     setStartDate(e.target.value);
@@ -25,7 +23,7 @@ const StartMeeting = () => {
   };
 
   const createRoomOption = () => {
-    setSelectedDates([]);
+    window.sessionStorage.clear();
     setDateRange({ startDate, endDate });
     router.push('/start/pick-calendar');
   };

--- a/src/components/room/meeting/place/search/SearchBar.tsx
+++ b/src/components/room/meeting/place/search/SearchBar.tsx
@@ -1,19 +1,18 @@
 'use client';
-import { type ChangeEvent, useState, useCallback } from 'react';
+import { type ChangeEvent, useState, useCallback, useRef } from 'react';
 import _ from 'lodash';
 import { useGetSearchPlace } from '@/hooks/useGetPlace';
 import { useSearchDataStore } from '@/store/placeStore';
-import { Input } from '@nextui-org/react';
 import SearchResultList from './SearchResultList';
-import styles from './SearchBar.module.css';
 import { SearchIcon } from './SearchIcon';
+import { Input } from '@nextui-org/react';
+import styles from './SearchBar.module.css';
 
 const SearchBar = () => {
   const [searchKeyword, setSearchKeyword] = useState('');
-  const [listViewState, setListViewState] = useState({
-    inputFocused: false,
-    containerHovered: false
-  });
+  const [listViewState, setListViewState] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
 
   const address = useSearchDataStore((state) => state.address);
 
@@ -24,12 +23,10 @@ const SearchBar = () => {
   const handleSearchInput = useCallback(_.debounce(handleChangeInput, 600), []);
 
   const handleInputFocus = () => {
-    setListViewState((prev) => ({ ...prev, inputFocused: !prev.inputFocused }));
+    setListViewState(true);
   };
 
   const { data: placeList, isPending } = useGetSearchPlace(searchKeyword);
-
-  const activatePlaceList = (listViewState.inputFocused && searchKeyword !== '') || listViewState.containerHovered;
 
   return (
     <div className={styles.container}>
@@ -39,15 +36,17 @@ const SearchBar = () => {
           placeholder={address}
           onChange={handleSearchInput}
           onFocus={handleInputFocus}
-          onBlur={handleInputFocus}
           autoComplete="off"
           startContent={<SearchIcon />}
           variant="bordered"
           size="lg"
           isClearable
+          ref={inputRef}
         />
       </form>
-      {activatePlaceList && <SearchResultList placeList={placeList} setListViewState={setListViewState} />}
+      {listViewState && (
+        <SearchResultList placeList={placeList} setListViewState={setListViewState} inputRef={inputRef} />
+      )}
     </div>
   );
 };

--- a/src/components/room/meeting/place/search/SearchResultList.tsx
+++ b/src/components/room/meeting/place/search/SearchResultList.tsx
@@ -1,42 +1,47 @@
-import React, { type Dispatch, type SetStateAction, type MouseEvent } from 'react';
-import styles from './SearchResultList.module.css';
-import { changeToViewPoint } from '@/utils/place/changeToViewPoint';
+import type { Dispatch, SetStateAction, MouseEvent, TouchEvent, MutableRefObject } from 'react';
 import { Place } from '@/types/place.types';
 import { useSearchDataStore } from '@/store/placeStore';
+import { changeToViewPoint } from '@/utils/place/changeToViewPoint';
+import styles from './SearchResultList.module.css';
 
-const SearchResultList = ({
-  placeList,
-  setListViewState
-}: {
+type Props = {
   placeList: Place[];
-  setListViewState: Dispatch<
-    SetStateAction<{
-      inputFocused: boolean;
-      containerHovered: boolean;
-    }>
-  >;
-}) => {
-  const setLocation = useSearchDataStore((state) => state.setLocation);
+  setListViewState: Dispatch<SetStateAction<boolean>>;
+  inputRef: MutableRefObject<HTMLInputElement | null>;
+};
 
-  const handleListFocus = (event: MouseEvent<HTMLDivElement>) => {
-    event.stopPropagation();
-    setListViewState((prev) => ({ ...prev, containerHovered: !prev.containerHovered }));
-  };
+const SearchResultList = ({ placeList, setListViewState, inputRef }: Props) => {
+  const setLocation = useSearchDataStore((state) => state.setLocation);
 
   const handleChangeViewPoint = (place: Place) => {
     const point = changeToViewPoint(place);
     setLocation(point);
   };
+
+  const handleClickList = (event: MouseEvent<HTMLLIElement>) => {
+    event.stopPropagation();
+    if (inputRef.current) inputRef.current.blur();
+    setListViewState(false);
+  };
+
+  const handleTouchList = (event: TouchEvent<HTMLLIElement>) => {
+    event.stopPropagation();
+    if (inputRef.current) inputRef.current.blur();
+    setListViewState(false);
+  };
+
   return (
-    <div className={styles.places_container} onMouseEnter={handleListFocus} onMouseLeave={handleListFocus}>
+    <div className={styles.places_container}>
       <ul>
         {placeList?.map((place) => (
           <li
             key={place.id}
-            onClick={() => {
+            onClick={(event) => {
+              handleClickList(event);
               handleChangeViewPoint(place);
             }}
-            onTouchEnd={() => {
+            onTouchEnd={(event) => {
+              handleTouchList(event);
               handleChangeViewPoint(place);
             }}
           >

--- a/src/hooks/useGeoLocation.ts
+++ b/src/hooks/useGeoLocation.ts
@@ -1,8 +1,7 @@
-import { useGpsStatusStore, useSearchDataStore } from '@/store/placeStore';
-import { myGeolocation } from '@/utils/place/myGeolocation';
 import { useEffect } from 'react';
-import { useQueryUser } from './useQueryUser';
+import { useGpsStatusStore, useSearchDataStore } from '@/store/placeStore';
 import { useRoomUserDataStore } from '@/store/roomUserStore';
+import { myGeolocation } from '@/utils/place/myGeolocation';
 
 export const useGeoLocation = () => {
   const setLocation = useSearchDataStore((state) => state.setLocation);
@@ -28,11 +27,9 @@ export const useGeoLocation = () => {
 
   useEffect(() => {
     if (roomUser && roomUser.start_location === '') {
-      console.log('if', roomUser, roomUser.start_location);
-      handleSetGeolocation();
-    } else {
-      console.log('else', roomUser, roomUser?.start_location);
       setIsGpsLoading(false);
+    } else {
+      handleSetGeolocation();
     }
   }, [roomUser?.start_location]);
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] inputRef 적용 focus control, 리스트 open 로직 수정
- [x] 검색 결과 list 클릭, 터치 이벤트 분리, 이벤트 발생 시 input blur 로직 추가
- [x] start, setting 경로에 따라 첫 지도 화면에 gps 조건 실행 수정
- [x] 모임 생성시 sessionStorage clear

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
검색바 input을 useRef로 연결
검색바를 focus 하면 list를 보여주는 listViewState를 ture로 해준다.
결과 list를 클릭, 터치 하면 해당 위치로 이동과 함께 useRef로 input blur 해주고 listViewState를 false로 변경해준다.

start, setting 경로에 따라 기존의 위치를 보여줄지 gps 연동을 통해 본인의 위치를 보여줄지의 조건 로직 수정

모임 생성 시 이전 방에서 설정한 state를 초기화 해주기 위해 sessionStorage clear 해준다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
![owl-list focus](https://github.com/where-we-meet/owl/assets/100992153/31775234-b599-4802-8d8c-1d3f91757971)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
