### PR TITLE
[fix/optimize] 유저 프로필 업로드 시 용량 관리를 위한 최적화 진행

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -92,18 +92,27 @@ export const changeUserProfile = async ({ userId, profile_url }: { userId: strin
 };
 
 //supabase store 이미지 업로드 로직
-export const uploadImage = async (file: File, setFile: Dispatch<SetStateAction<File | null>>) => {
+export const uploadImage = async ({
+  file,
+  setFile,
+  userID
+}: {
+  file: File;
+  setFile: Dispatch<SetStateAction<File | null>>;
+  userID: string;
+}) => {
   const file_name = getFileName();
 
   if (file) {
-    const { data, error } = await supabase.storage.from('images').upload(`users_profile/${file_name}`, file);
+    const { data, error } = await supabase.storage.from('images').upload(`users_profile/${userID}/${file_name}`, file);
     setFile(null);
 
     if (error) {
       alert(`이미지 업로드에 실패하였습니다.\n 원인 : ${error.message} `);
     } else {
       alert(`이미지를 성공적으로 업로드하였습니다.`);
-      return `${process.env.NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${file_name}`;
+      return `${process.env
+        .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${userID}/${file_name}`;
     }
   }
 };

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -117,6 +117,22 @@ export const uploadImage = async ({
   }
 };
 
+const _deleteProfileImage = async ({ userID }: { userID: string }) => {
+  const { data, error } = await supabase.storage.from(`images/${userID}`).remove(['*']);
+  if (error) throw error;
+};
+
+const _findCurrentProfileImage = async ({ userID }: { userID: string }) => {
+  const folderPath = `users_profile/${userID}/`;
+  const { data: files, error } = await supabase.storage.from('images').list(folderPath);
+
+  if (error) throw error;
+  if (files && files.length > 0) {
+    const profilePicUrl = supabase.storage.from('images').getPublicUrl(files[0].name);
+    return profilePicUrl.data.publicUrl;
+  }
+  return null;
+};
 // supabase useres table에서 user Name 변경
 export const updateUserName = async (userId: string, newName: string) => {
   const { error } = await supabase.from('users').update({ name: newName }).eq('id', userId);

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -111,15 +111,22 @@ export const uploadImage = async ({
       alert(`이미지 업로드에 실패하였습니다.\n 원인 : ${error.message} `);
     } else {
       alert(`이미지를 성공적으로 업로드하였습니다.`);
+      //기존 프로필 이미지 삭제
+      await _deletePastProfileImage({ userID });
       return `${process.env
         .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${userID}/${file_name}`;
     }
   }
 };
 
-const _deleteProfileImage = async ({ userID }: { userID: string }) => {
-  const { data, error } = await supabase.storage.from(`images/${userID}`).remove(['*']);
-  if (error) throw error;
+const _deletePastProfileImage = async ({ userID }: { userID: string }) => {
+  const fileURL = await _findCurrentProfileImage({ userID });
+  if (fileURL !== null) {
+    const { data, error } = await supabase.storage.from(`images`).remove([`users_profile/${userID}/${fileURL}`]);
+    if (error) throw error;
+    return true;
+  }
+  return false;
 };
 
 const _findCurrentProfileImage = async ({ userID }: { userID: string }) => {

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -96,17 +96,17 @@ export const changeUserProfile = async ({ userId, profile_url }: { userId: strin
 export const uploadImage = async ({
   file,
   setFile,
-  userID
+  userId
 }: {
   file: File;
   setFile: Dispatch<SetStateAction<File | null>>;
-  userID: string;
+  userId: string;
 }) => {
-  const currentFileURL = await findCurrentProfileImage({ userID });
+  const currentFileURL = await findCurrentProfileImage({ userId });
   const file_name = getFileName();
 
   if (file) {
-    const { data, error } = await supabase.storage.from('images').upload(`users_profile/${userID}/${file_name}`, file);
+    const { data, error } = await supabase.storage.from('images').upload(`users_profile/${userId}/${file_name}`, file);
     setFile(null);
 
     if (error) {
@@ -114,25 +114,25 @@ export const uploadImage = async ({
     } else {
       alert(`이미지를 성공적으로 업로드하였습니다.`);
       //기존 프로필 이미지 삭제
-      await deleteProfileImage({ userID, fileURL: currentFileURL });
+      await deleteProfileImage({ userId, fileURL: currentFileURL });
       return `${process.env
-        .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${userID}/${file_name}`;
+        .NEXT_PUBLIC_SUPABASE_URL!}/storage/v1/object/public/images/users_profile/${userId}/${file_name}`;
     }
   }
 };
 
-export const deleteProfileImage = async ({ userID, fileURL }: { userID: string; fileURL: string | null }) => {
+export const deleteProfileImage = async ({ userId, fileURL }: { userId: string; fileURL: string | null }) => {
   if (fileURL !== null) {
     const fileName = extractFileNameFromURL(fileURL);
-    const { error } = await supabase.storage.from('images').remove([`users_profile/${userID}/${fileName}`]);
+    const { error } = await supabase.storage.from('images').remove([`users_profile/${userId}/${fileName}`]);
     if (error) throw error;
     return true;
   }
   return false;
 };
 
-export const findCurrentProfileImage = async ({ userID }: { userID: string }) => {
-  const folderPath = `users_profile/${userID}/`;
+export const findCurrentProfileImage = async ({ userId }: { userId: string }) => {
+  const folderPath = `users_profile/${userId}/`;
   const { data: files, error } = await supabase.storage.from('images').list(folderPath);
 
   if (error) throw error;

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -122,7 +122,7 @@ export const uploadImage = async ({
 const _deletePastProfileImage = async ({ userID }: { userID: string }) => {
   const fileURL = await _findCurrentProfileImage({ userID });
   if (fileURL !== null) {
-    const { data, error } = await supabase.storage.from(`images`).remove([`users_profile/${userID}/${fileURL}`]);
+    const { error } = await supabase.storage.from('images').remove([`${fileURL}`]);
     if (error) throw error;
     return true;
   }

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -55,8 +55,8 @@ const UserProfileUpdate = ({
       await updateUserName(user.id, userName);
       if (userProfileURL !== '' && userProfileURL !== null) {
         //기존 프로필 이미지 삭제
-        const fileURL = await findCurrentProfileImage({ userID: user.id });
-        await deleteProfileImage({ userID: user.id, fileURL });
+        const fileURL = await findCurrentProfileImage({ userId: user.id });
+        await deleteProfileImage({ userId: user.id, fileURL });
         await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
       }
       toggleEditMode();
@@ -115,7 +115,7 @@ const UserProfileUpdate = ({
           <ImageUploadModal
             handleToggleModal={handleToggleModal}
             setUserProfileURL={setUserProfileURL}
-            userID={user.id}
+            userId={user.id}
           />
         )}
       </ModalBody>

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -3,7 +3,12 @@
 import { ChangeEvent, useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Button, ModalHeader, ModalBody, Avatar } from '@nextui-org/react';
-import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
+import {
+  changeUserProfile,
+  deleteProfileImage,
+  findCurrentProfileImage,
+  updateUserName
+} from '@/api/supabaseCSR/supabase';
 import { getUserProfileData } from '@/api/profile';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { ImageUploadModal } from '../../my-owl/profile/modal/Modal';
@@ -48,7 +53,10 @@ const UserProfileUpdate = ({
       alert('닉네임은 최대 16글자 이하로 지어주세요.');
     } else {
       await updateUserName(user.id, userName);
-      if (userProfileURL !== null) {
+      if (userProfileURL !== '' && userProfileURL !== null) {
+        //기존 프로필 이미지 삭제
+        const fileURL = await findCurrentProfileImage({ userID: user.id });
+        await deleteProfileImage({ userID: user.id, fileURL });
         await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
       }
       toggleEditMode();

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -104,7 +104,11 @@ const UserProfileUpdate = ({
         </div>
 
         {toggleModal && (
-          <ImageUploadModal handleToggleModal={handleToggleModal} setUserProfileURL={setUserProfileURL} />
+          <ImageUploadModal
+            handleToggleModal={handleToggleModal}
+            setUserProfileURL={setUserProfileURL}
+            userID={user.id}
+          />
         )}
       </ModalBody>
     </>

--- a/src/components/my-owl/profile/modal/Modal.tsx
+++ b/src/components/my-owl/profile/modal/Modal.tsx
@@ -13,11 +13,11 @@ const MAX_FILE_SIZE_BYTE = 2097152; //2MB
 export const ImageUploadModal = ({
   handleToggleModal,
   setUserProfileURL,
-  userID
+  userId
 }: {
   handleToggleModal: () => void;
   setUserProfileURL: Dispatch<SetStateAction<string | null>>;
-  userID: string;
+  userId: string;
 }) => {
   const [file, setFile] = useState<File | null>(null);
   const [url, setUrl] = useState('');
@@ -53,7 +53,7 @@ export const ImageUploadModal = ({
   const handleUploadImage = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (file !== null) {
-      const profile_url = await uploadImage({ file, setFile, userID });
+      const profile_url = await uploadImage({ file, setFile, userId });
       handleToggleModal();
       profile_url ? setUserProfileURL(profile_url) : alert(`문제가 발생하였습니다`);
     } else {

--- a/src/components/my-owl/profile/modal/Modal.tsx
+++ b/src/components/my-owl/profile/modal/Modal.tsx
@@ -34,7 +34,7 @@ export const ImageUploadModal = ({
     return isValidFileSize(file);
   };
 
-  const handleChangeFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChangeFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target;
     if (files !== null && files !== undefined) {
       const file = files[0];

--- a/src/components/my-owl/profile/modal/Modal.tsx
+++ b/src/components/my-owl/profile/modal/Modal.tsx
@@ -12,10 +12,12 @@ const MAX_FILE_SIZE_BYTE = 2097152; //2MB
 
 export const ImageUploadModal = ({
   handleToggleModal,
-  setUserProfileURL
+  setUserProfileURL,
+  userID
 }: {
   handleToggleModal: () => void;
   setUserProfileURL: Dispatch<SetStateAction<string | null>>;
+  userID: string;
 }) => {
   const [file, setFile] = useState<File | null>(null);
   const [url, setUrl] = useState('');
@@ -51,7 +53,7 @@ export const ImageUploadModal = ({
   const handleUploadImage = async (e: MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
     if (file !== null) {
-      const profile_url = await uploadImage(file, setFile);
+      const profile_url = await uploadImage({ file, setFile, userID });
       handleToggleModal();
       profile_url ? setUserProfileURL(profile_url) : alert(`문제가 발생하였습니다`);
     } else {

--- a/src/utils/extractFileNameFromURL.ts
+++ b/src/utils/extractFileNameFromURL.ts
@@ -1,0 +1,4 @@
+export const extractFileNameFromURL = (url: string) => {
+  const fileName = url.substring(url.lastIndexOf('/') + 1);
+  return fileName;
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #227 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 유저 프로필 사진 업로드 시, 유저 아이디 별로 폴더를 생성하여 유저 프로필 사진을 업로드한다.
- [x] 유저가 새로운 프로필 사진 업로드 또는 url로 지정할 때, supabase storage에 존재하는 해당 유저의 프로필사진을 삭제하여 용량 리소스를 아낀다. 

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
유저 프로필 업로드 시 용량 관리를 위한 최적화를 진행하였습니다.
삭제 경로 지정을 위해, 프로필 사진의 경로를 받아 이름을 추출하는 extractFileNameFromURL 함수를 작성하여 사용했습니다.
- 한 유저 당 스토어에 저장된 프로필 사진 파일은 무조건 하나가 되도록 로직을 수정하였습니다.

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
supabase store에서 파일을 삭제할 때, 이미지의 URL이 아닌 경로를 지정해서만 삭제가 가능합니다.
- https://supabase.com/docs/reference/javascript/storage-from-remove