### PR TITLE
[fix/profile] 프로필 수정 시, 닉네임 입력 가능 글자 수를 최대 닉네임 글자수로 제한하기

### DIFF
--- a/src/components/header/profile/UserProfileButton.module.css
+++ b/src/components/header/profile/UserProfileButton.module.css
@@ -16,7 +16,7 @@
 }
 
 .profile:hover {
-  outline-color: black;
+  outline-color: #7a20be;
 }
 
 .view_profile_container {

--- a/src/components/header/profile/UserProfileButton.module.css
+++ b/src/components/header/profile/UserProfileButton.module.css
@@ -48,7 +48,7 @@
 
 .view_profile_text {
   font-size: 0.8rem;
-  width: 110%;
+  width: 9rem;
   color: #7a20be;
   padding: 0.4rem 0.2rem;
   margin: 0.3rem;

--- a/src/components/header/profile/UserProfileRead.module.css
+++ b/src/components/header/profile/UserProfileRead.module.css
@@ -15,7 +15,7 @@
 .modal_body {
   overflow: hidden;
   align-items: center;
-  padding-top: 3.75rem;
+  padding-top: 2rem;
 }
 
 .profile {
@@ -66,6 +66,7 @@
 
 .next_icon {
   scale: 1.7;
+  color: #7a20be;
 }
 
 .login_info_container {
@@ -98,11 +99,13 @@
   color: rgb(155, 155, 155);
 }
 
-@media screen and (max-width: 768px) {
-  .modal_body {
-    padding-top: 2rem;
-  }
+.info_container {
+  display: flex;
+  flex-direction: column;
+  min-width: 15rem;
+}
 
+@media screen and (max-width: 768px) {
   .name_container {
     min-width: auto;
   }
@@ -122,7 +125,6 @@
   .login_info_container > p {
     font-size: 0.9rem;
   }
-
   .user_edit_container > p {
     font-size: 1rem;
   }

--- a/src/components/header/profile/UserProfileRead.tsx
+++ b/src/components/header/profile/UserProfileRead.tsx
@@ -59,7 +59,7 @@ const UserProfileRead = ({
       </ModalHeader>
       <ModalBody className={styles.modal_body}>
         <Avatar className={styles.profile} showFallback alt="profile_image" src={`${data.profile_url}`} />
-        <div>
+        <div className={styles.info_container}>
           <div className={styles.name_container}>
             <p>닉네임</p>
             <div className={styles.user_edit_container}>

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -16,7 +16,7 @@ import { IoChevronBack } from 'react-icons/io5';
 import { AiFillPlusCircle } from 'react-icons/ai';
 
 import styles from './UserProfileUpdate.module.css';
-const MAX_NAME_LENGTH = 16;
+const MAX_NAME_LENGTH = 8;
 
 const UserProfileUpdate = ({
   toggleEditMode,
@@ -49,8 +49,8 @@ const UserProfileUpdate = ({
   const handleEditDone = async () => {
     if (userName.length < 1) {
       alert('닉네임은 최소 1글자 이상으로 지어주세요.');
-    } else if (userName.length > 16) {
-      alert('닉네임은 최대 16글자 이하로 지어주세요.');
+    } else if (userName.length > MAX_NAME_LENGTH) {
+      alert(`닉네임은 최대 ${MAX_NAME_LENGTH}글자 이하로 지어주세요.`);
     } else {
       await updateUserName(user.id, userName);
       if (userProfileURL !== '' && userProfileURL !== null) {
@@ -101,7 +101,14 @@ const UserProfileUpdate = ({
                 <span className={styles.current_name_length}>{userName.length}</span>/{MAX_NAME_LENGTH}
               </p>
             </span>
-            <input id="name" type="text" onChange={handleChangeUserName} value={userName} autoFocus />
+            <input
+              id="name"
+              type="text"
+              onChange={handleChangeUserName}
+              value={userName}
+              autoFocus
+              autoComplete="off"
+            />
           </div>
           <Button className={styles.save_button} onPress={handleEditDone}>
             저장

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -106,6 +106,7 @@ const UserProfileUpdate = ({
               type="text"
               onChange={handleChangeUserName}
               value={userName}
+              maxLength={MAX_NAME_LENGTH}
               autoFocus
               autoComplete="off"
             />


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #231 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 프로필 수정 시, 닉네임 입력 가능 글자 수를 최대 닉네임 글자수(8)로 제한하였습니다.
- [x] 드롭다운의 내 프로필 보기 버튼의 width를 고정 설정하였습니다. (기존에는 닉네임 글자수에 따라 width가 바뀌었습니다)
- [x] 프로필 조회 시 모바일 UI가 적절하지 못해 수정하였습니다.
- [x] 프로필 수정 모달로의 이동 버튼에 색상을 추가하여 UX를 개선하였습니다.
- [x] 헤더에 있는 프로필 사진에 hover 시, outline-color를 키컬러로 설정하여 통일감을 주었습니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
UI를 고려하여 닉네임 최대 길이를 8자로 수정하였습니다.
또한 프로필 조회 시 모바일 화면에서의 UI를 개선하고, 프로필 수정으로의 이동 버튼에 색상을 추가하여 UX를 개선하였습니다. 
추가적으로, 헤더의 프로필 사진 hover 시 outline-color를 키 컬러로 설정하여 통일감을 주었습니다.

## 📸 스크린샷(선택)
<img width="250" alt="스크린샷 2024-04-20 오후 5 56 33" src="https://github.com/where-we-meet/owl/assets/69431340/856fddff-e58e-4425-9a7b-b7eb44ba3286">
<img width="250" alt="스크린샷 2024-04-20 오후 5 57 30" src="https://github.com/where-we-meet/owl/assets/69431340/34c924cf-36a6-4c52-9317-3412d87cf582">
<br/>

<img width="250" alt="스크린샷 2024-04-20 오후 5 56 49" src="https://github.com/where-we-meet/owl/assets/69431340/cc930e97-b015-43b0-af4d-c619207eb882">



<img width="250" alt="스크린샷 2024-04-20 오후 5 57 51" src="https://github.com/where-we-meet/owl/assets/69431340/d157d419-e2a7-492f-878f-6e44a71cb967">

![화면 기록 2024-04-20 오후 5 58 09](https://github.com/where-we-meet/owl/assets/69431340/8c056f9c-cc1a-447e-93c3-6dacb6b4a1ad)


