### PR TITLE
[fix/image upload] 이미지 업로드 시 파일이 이중으로 업로드 되는 문제 해결 (새로고침 제외)

### DIFF
--- a/src/components/header/profile/ProfileModal.tsx
+++ b/src/components/header/profile/ProfileModal.tsx
@@ -4,18 +4,29 @@ import UserProfileRead from './UserProfileRead';
 import { useState } from 'react';
 
 import styles from './ProfileModal.module.css';
+import { useRoomUserDataStore } from '@/store/userProfileStore';
+import { deleteProfileImage } from '@/api/supabaseCSR/supabase';
+import { useQueryUser } from '@/hooks/useQueryUser';
 
 export const ProfileModal = ({ onClose, isOpen }: { onClose: () => void; isOpen: boolean }) => {
   const [editMode, setEditMode] = useState(false);
-  const handleClose = () => {
-    if (editMode && !confirm('변경사항이 저장되지 않을 수 있습니다. 그래도 나가시겠습니까?')) return;
-    // 업로드했던 프로필 사진 삭제
+  const user = useQueryUser();
+  const { uploadedProfileURL, setUploadedProfileURL } = useRoomUserDataStore();
+  const handleClose = async () => {
+    if (editMode) {
+      const isAgree = confirm('변경사항이 저장되지 않을 수 있습니다. 그래도 나가시겠습니까?');
+      if (isAgree) {
+        // 업로드하고 저장하지 않은 프로필이 있다면 삭제
+        await deleteProfileImage({ userId: user.id, fileURL: uploadedProfileURL });
+        setUploadedProfileURL('');
+      } else return;
+    }
 
     setEditMode(false);
     onClose();
   };
 
-  const toggleEditMode = () => {
+  const toggleEditMode = async () => {
     setEditMode((prev) => !prev);
   };
 

--- a/src/components/header/profile/ProfileModal.tsx
+++ b/src/components/header/profile/ProfileModal.tsx
@@ -9,6 +9,8 @@ export const ProfileModal = ({ onClose, isOpen }: { onClose: () => void; isOpen:
   const [editMode, setEditMode] = useState(false);
   const handleClose = () => {
     if (editMode && !confirm('변경사항이 저장되지 않을 수 있습니다. 그래도 나가시겠습니까?')) return;
+    // 업로드했던 프로필 사진 삭제
+
     setEditMode(false);
     onClose();
   };

--- a/src/components/header/profile/UserProfileRead.tsx
+++ b/src/components/header/profile/UserProfileRead.tsx
@@ -10,6 +10,7 @@ import { IoClose } from 'react-icons/io5';
 import styles from './UserProfileRead.module.css';
 import Logout from '../../auth/LogoutButton';
 import { UserProfileData } from './UserProfileButton';
+import { useRoomUserDataStore } from '@/store/userProfileStore';
 
 const UserProfileRead = ({
   toggleEditMode,
@@ -21,6 +22,7 @@ const UserProfileRead = ({
   isOpen: boolean;
 }) => {
   const user = useQueryUser();
+  const { setCurrentProfileURL } = useRoomUserDataStore();
   //state for recent profile data (from supabase DB)
   const [data, setData] = useState<UserProfileData>({
     name: '',
@@ -33,6 +35,7 @@ const UserProfileRead = ({
       try {
         const data = await getUserProfileData(user.id);
         setData({ name: data.name, profile_url: data.profile_url });
+        setCurrentProfileURL(data.profile_url);
       } catch (error) {
         console.error('Error fetching user profile data:', error);
       }

--- a/src/components/header/profile/UserProfileRead.tsx
+++ b/src/components/header/profile/UserProfileRead.tsx
@@ -22,7 +22,7 @@ const UserProfileRead = ({
   isOpen: boolean;
 }) => {
   const user = useQueryUser();
-  const { setCurrentProfileURL } = useRoomUserDataStore();
+  const { setCurrentProfileURL, setUploadedProfileURL } = useRoomUserDataStore();
   //state for recent profile data (from supabase DB)
   const [data, setData] = useState<UserProfileData>({
     name: '',
@@ -36,6 +36,7 @@ const UserProfileRead = ({
         const data = await getUserProfileData(user.id);
         setData({ name: data.name, profile_url: data.profile_url });
         setCurrentProfileURL(data.profile_url);
+        setUploadedProfileURL('');
       } catch (error) {
         console.error('Error fetching user profile data:', error);
       }

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -28,7 +28,7 @@ const UserProfileUpdate = ({
   const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
   const [toggleModal, setToggleModal] = useState(false);
-  const { setUploadedProfileURL, currentProfileURL } = useRoomUserDataStore();
+  const { setUploadedProfileURL, setCurrentProfileURL, currentProfileURL, uploadedProfileURL } = useRoomUserDataStore();
 
   const user = useQueryUser();
   const { data, isLoading } = useQuery({
@@ -62,10 +62,19 @@ const UserProfileUpdate = ({
     }
   };
 
+  const handleEditExit = async () => {
+    // 업로드 된 이미지 삭제
+    await deleteProfileImage({ userId: user.id, fileURL: uploadedProfileURL });
+    setUploadedProfileURL('');
+    toggleEditMode();
+  };
+
   useEffect(() => {
     if (data) {
       setUserName(data.name);
       setUserProfileURL(data.profile_url);
+      setUploadedProfileURL('');
+      setCurrentProfileURL(data.profile_url);
     }
   }, [data]);
 
@@ -82,7 +91,7 @@ const UserProfileUpdate = ({
 
   return (
     <>
-      <Button className={styles.back_btn} isIconOnly onPress={toggleEditMode}>
+      <Button className={styles.back_btn} isIconOnly onPress={handleEditExit}>
         <IoChevronBack />
       </Button>
       <ModalHeader className="flex flex-col gap-1 text-center">

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -78,14 +78,25 @@ const UserProfileUpdate = ({
     }
   }, [data]);
 
+  const handleUnload = async (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    await deleteProfileImage({ userId: user.id, fileURL: uploadedProfileURL });
+    setUploadedProfileURL('');
+
+    return '';
+  };
+
   useEffect(() => {
     if (isOpen) {
       window.addEventListener('popstate', handleClose);
+      window.addEventListener('beforeunload', handleUnload);
     } else {
       window.removeEventListener('popstate', handleClose);
+      window.removeEventListener('beforeunload', handleUnload);
     }
     return () => {
       window.removeEventListener('popstate', handleClose);
+      window.removeEventListener('beforeunload', handleUnload);
     };
   }, [isOpen]);
 

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -1,21 +1,18 @@
 'use client';
 
-import { ChangeEvent, useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Button, ModalHeader, ModalBody, Avatar } from '@nextui-org/react';
-import {
-  changeUserProfile,
-  deleteProfileImage,
-  findCurrentProfileImage,
-  updateUserName
-} from '@/api/supabaseCSR/supabase';
+import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
 import { getUserProfileData } from '@/api/profile';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { ImageUploadModal } from '../../my-owl/profile/modal/Modal';
+
 import { IoChevronBack } from 'react-icons/io5';
 import { AiFillPlusCircle } from 'react-icons/ai';
-
 import styles from './UserProfileUpdate.module.css';
+
 const MAX_NAME_LENGTH = 8;
 
 const UserProfileUpdate = ({

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -12,6 +12,7 @@ import { ImageUploadModal } from '../../my-owl/profile/modal/Modal';
 import { IoChevronBack } from 'react-icons/io5';
 import { AiFillPlusCircle } from 'react-icons/ai';
 import styles from './UserProfileUpdate.module.css';
+import { useRoomUserDataStore } from '@/store/userProfileStore';
 
 const MAX_NAME_LENGTH = 8;
 
@@ -27,6 +28,7 @@ const UserProfileUpdate = ({
   const [userName, setUserName] = useState('');
   const [userProfileURL, setUserProfileURL] = useState<string | null>('');
   const [toggleModal, setToggleModal] = useState(false);
+  const { setUploadedProfileURL, currentProfileURL } = useRoomUserDataStore();
 
   const user = useQueryUser();
   const { data, isLoading } = useQuery({
@@ -52,9 +54,10 @@ const UserProfileUpdate = ({
       await updateUserName(user.id, userName);
       if (userProfileURL !== '' && userProfileURL !== null) {
         // 기존 프로필 삭제
-        await deleteProfileImage({ userId: user.id, fileURL: user.user_metadata.profile_url });
+        await deleteProfileImage({ userId: user.id, fileURL: currentProfileURL });
         await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
       }
+
       toggleEditMode();
     }
   };

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -4,7 +4,7 @@ import type { ChangeEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Button, ModalHeader, ModalBody, Avatar } from '@nextui-org/react';
-import { changeUserProfile, updateUserName } from '@/api/supabaseCSR/supabase';
+import { changeUserProfile, deleteProfileImage, updateUserName } from '@/api/supabaseCSR/supabase';
 import { getUserProfileData } from '@/api/profile';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { ImageUploadModal } from '../../my-owl/profile/modal/Modal';
@@ -51,6 +51,8 @@ const UserProfileUpdate = ({
     } else {
       await updateUserName(user.id, userName);
       if (userProfileURL !== '' && userProfileURL !== null) {
+        // 기존 프로필 삭제
+        await deleteProfileImage({ userId: user.id, fileURL: user.user_metadata.profile_url });
         await changeUserProfile({ userId: user.id, profile_url: userProfileURL });
       }
       toggleEditMode();

--- a/src/components/header/profile/UserProfileUpdate.tsx
+++ b/src/components/header/profile/UserProfileUpdate.tsx
@@ -80,9 +80,6 @@ const UserProfileUpdate = ({
 
   const handleUnload = async (e: BeforeUnloadEvent) => {
     e.preventDefault();
-    await deleteProfileImage({ userId: user.id, fileURL: uploadedProfileURL });
-    setUploadedProfileURL('');
-
     return '';
   };
 
@@ -92,11 +89,11 @@ const UserProfileUpdate = ({
       window.addEventListener('beforeunload', handleUnload);
     } else {
       window.removeEventListener('popstate', handleClose);
-      window.removeEventListener('beforeunload', handleUnload);
+      window.addEventListener('beforeunload', handleUnload);
     }
     return () => {
       window.removeEventListener('popstate', handleClose);
-      window.removeEventListener('beforeunload', handleUnload);
+      window.addEventListener('beforeunload', handleUnload);
     };
   }, [isOpen]);
 

--- a/src/components/my-owl/profile/modal/Modal.module.css
+++ b/src/components/my-owl/profile/modal/Modal.module.css
@@ -50,7 +50,7 @@
 .upload_file_container {
   height: 100%;
   border-radius: 5px;
-  padding: 2rem;
+  padding: 1rem;
 
   text-align: center;
   text-decoration: underline;
@@ -162,4 +162,12 @@
 .preview_image {
   max-width: 10rem;
   max-height: 10rem;
+  object-fit: contain;
+}
+
+.change_file_label {
+  font-weight: 500;
+  font-size: 1rem;
+  margin-top: 0.8rem;
+  cursor: pointer;
 }

--- a/src/components/my-owl/profile/modal/Modal.tsx
+++ b/src/components/my-owl/profile/modal/Modal.tsx
@@ -133,7 +133,14 @@ export const ImageUploadModal = ({
               <AiOutlinePicture style={{ scale: '1.8' }} />내 폴더에서 사진 찾기
             </label>
           ) : (
-            preview && <img src={preview as string} className={styles.preview_image} alt="profile-preview" />
+            preview && (
+              <div style={{ display: 'flex', flexDirection: 'column' }}>
+                <img src={preview as string} className={styles.preview_image} alt="profile-preview" />
+                <label className={styles.change_file_label} htmlFor="file">
+                  다른 사진 찾기
+                </label>
+              </div>
+            )
           )}
         </div>
         <button className={styles.file_upload_btn} disabled={file === null} onClick={handleUploadImage}>

--- a/src/components/room/place/ResultMap.module.css
+++ b/src/components/room/place/ResultMap.module.css
@@ -22,6 +22,7 @@
   z-index: 11;
   transform: translate(-50%, -44%);
   transition: top 0.3s ease, opacity 0.3s ease;
+  user-select: none;
 }
 
 .center_address {

--- a/src/store/userProfileStore.ts
+++ b/src/store/userProfileStore.ts
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+type userProfileData = {
+  currentProfileURL: string | null;
+  uploadedProfileURL: string;
+  setCurrentProfileURL: (profileURL: string) => void;
+  setUploadedProfileURL: (profileURL: string) => void;
+};
+
+export const useRoomUserDataStore = create((set) => ({
+  currentProfileURL: '',
+  uploadedProfileURL: '',
+  setCurrentProfileURL: (profileURL: string) => set({ currentProfileURL: profileURL }),
+  setUploadedProfileURL: (profileURL: string) => set({ uploadedProfileURL: profileURL })
+}));

--- a/src/store/userProfileStore.ts
+++ b/src/store/userProfileStore.ts
@@ -1,15 +1,15 @@
 import { create } from 'zustand';
 
-type userProfileData = {
+type UserProfileData = {
   currentProfileURL: string | null;
   uploadedProfileURL: string;
-  setCurrentProfileURL: (profileURL: string) => void;
+  setCurrentProfileURL: (profileURL: string | null) => void;
   setUploadedProfileURL: (profileURL: string) => void;
 };
 
-export const useRoomUserDataStore = create((set) => ({
+export const useRoomUserDataStore = create<UserProfileData>((set) => ({
   currentProfileURL: '',
   uploadedProfileURL: '',
-  setCurrentProfileURL: (profileURL: string) => set({ currentProfileURL: profileURL }),
+  setCurrentProfileURL: (profileURL: string | null) => set({ currentProfileURL: profileURL }),
   setUploadedProfileURL: (profileURL: string) => set({ uploadedProfileURL: profileURL })
 }));


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 새로 고침 전 알림창 표시
- [x] 이미지 업로드 관련 비동기 데이터 처리 로직 강화

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
이미지 업로드 관련 비동기 데이터 처리 로직 강화 (새로고침 제외), 새로 고침 전 알림창 표시 작업을 하였습니다.

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
업로드 후 저장 전에 새로고침 하는 경우, 업로드 한 이미지를 삭제할 수 없습니다. (디비에서 삭제해야 함)
해결해보려고 온갖시도를 했지만, 브라우저 자체의 한계인 것 같습니다. (보안 이슈)
한국어로 검색해도 자료가 잘 안나와요. 보안 상 문제로 새로고침 시 비동기 작업, 커스텀 알럿창 작업이 불가능하도록 해놓은 것 같습니다.
누군가가 업로드하고 저장 하기 전 새로고침을 무한 반복하면,, 물론 최대 2MB로 업로드 제한을 해놓긴 했지만요..
보안 상 좋지 않은 이미지 처리 방식인 것 같아서 슬픕니다.

사실 첫 단추부터 잘못 끼워진 것 같은 느낌이 들지만...
(그래서 그런지 이미지 업로드 관련 로직이 매우매우매우 복잡한 상태입니다.)

시간 관계상 다 뒤집어 엎는 것은 힘드니 일단 이대로 가겠습니다 엉엉...
**나중에 디자인까지 끝나고 시간이 생긴다면 리팩터링 1순위입니다.**
그래도 새로 고침 전 알림창은 뜨게 해놨습니다.

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- [프론트엔드 개발자라면 알아야 할 브라우저의 동작 과정](https://yozm.wishket.com/magazine/detail/1338/)
- https://leteu.tistory.com/17
## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
새로고침 제외 모든 경우의 수를 테스트 해주세요.  
문제 생기면 저에게 알려주십시오 ㅎㅎ.....
