### PR TITLE
[fix/start-location-box] 출발 위치 고정일 때 지도 이동 시 출발 위치 내용도 고정으로 수정

### DIFF
--- a/src/components/room/place/StartLocationBox.tsx
+++ b/src/components/room/place/StartLocationBox.tsx
@@ -13,7 +13,9 @@ const StartLocationBox = () => {
     <div>
       <div className={styles.label}>출발 위치</div>
       <div className={styles.wrapper}>
-        <div className={`${styles.box} ${isPinned && styles.selected}  `}>{address}</div>
+        <div className={`${styles.box} ${isPinned && styles.selected}  `}>
+          {isPinned ? roomUser.start_location : address}
+        </div>
         <LocationSwitch toggleState={isPinned} />
       </div>
     </div>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 출발위치 내용을 고정 상태일 때 바뀌지 않게 수정
## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
출발 위치를 고정 했을 때 지도를 이동하면 고정된 출발 위치 내용이 현재 지도의 중심으로 나오는 현상 수정
-> isPinned 가 true일 때 db의 start_location을 보여주고 false일 때 store의 중심 위치 상태로 보여주도록 변경하였습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
![owl-출발위치 고정시키기](https://github.com/where-we-meet/owl/assets/100992153/c4ced077-c647-4822-9949-90e39786b66f)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
