### PR TITLE
[style/calendar] 캘린더 관련 디자인 수정, 사이드바 일부 수정

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -42,6 +42,12 @@ export const getRoomData = async (roomId: string) => {
   return data[0];
 };
 
+export const getRoomParticipantNumber = async (roomId: string) => {
+  const { data, error } = await supabase.from('userdata_room').select('user_id').eq('room_id', roomId);
+  if (error) throw error;
+  return data.length;
+};
+
 export const getRoomUsersData = async (id: string) => {
   const { data, error } = await supabase
     .from('userdata_room')

--- a/src/components/room/calender/Calender.module.css
+++ b/src/components/room/calender/Calender.module.css
@@ -9,7 +9,7 @@
 .calendar_header {
   width: 100%;
   display: flex;
-  justify-content: center;
+  justify-content: space-between;
   align-items: center;
   gap: 1rem;
 }

--- a/src/components/room/calender/Calender.module.css
+++ b/src/components/room/calender/Calender.module.css
@@ -16,7 +16,7 @@
 
 .calendar_month_container {
   display: flex;
-  align-items: center;
+  align-items: last baseline;
   gap: 1rem;
   min-width: 3rem;
 }

--- a/src/components/room/calender/Calender.tsx
+++ b/src/components/room/calender/Calender.tsx
@@ -85,7 +85,9 @@ const Calender = () => {
             <Button isIconOnly onPress={prevMonth} className={styles.calendar_month_controller}>
               <IoChevronBackSharp />
             </Button>
-            <span className={styles.calendar_month}>{`${nowDate.getFullYear()}-${getMonth()}`}</span>
+            <span
+              className={styles.calendar_month}
+            >{`${nowDate.getFullYear()}-${getMonth()} ${participantNumber}`}</span>
             <Button isIconOnly onPress={afterMonth} className={styles.calendar_month_controller}>
               <IoChevronForwardSharp />
             </Button>

--- a/src/components/room/calender/Calender.tsx
+++ b/src/components/room/calender/Calender.tsx
@@ -85,9 +85,7 @@ const Calender = () => {
             <Button isIconOnly onPress={prevMonth} className={styles.calendar_month_controller}>
               <IoChevronBackSharp />
             </Button>
-            <span
-              className={styles.calendar_month}
-            >{`${nowDate.getFullYear()}-${getMonth()} ${participantNumber}`}</span>
+            <span className={styles.calendar_month}>{`${nowDate.getFullYear()}-${getMonth()}`}</span>
             <Button isIconOnly onPress={afterMonth} className={styles.calendar_month_controller}>
               <IoChevronForwardSharp />
             </Button>

--- a/src/components/room/calender/Calender.tsx
+++ b/src/components/room/calender/Calender.tsx
@@ -64,7 +64,10 @@ const Calender = () => {
 
     insertSchedule.mutate({ roomId, userId, date });
   };
-
+  const getMonth = () => {
+    const month = nowDate.getMonth() + 1 + '';
+    return month.length < 2 ? '0' + month : month;
+  };
   return (
     <>
       <div className={styles.calendar_container}>
@@ -73,7 +76,7 @@ const Calender = () => {
             <Button isIconOnly onPress={prevMonth} className={styles.calendar_month_controller}>
               <IoChevronBackSharp />
             </Button>
-            <span className={styles.calendar_month}>{`${nowDate.getFullYear()}-${nowDate.getMonth() + 1}`}</span>
+            <span className={styles.calendar_month}>{`${nowDate.getFullYear()}-${getMonth()}`}</span>
             <Button isIconOnly onPress={afterMonth} className={styles.calendar_month_controller}>
               <IoChevronForwardSharp />
             </Button>

--- a/src/components/room/calender/Calender.tsx
+++ b/src/components/room/calender/Calender.tsx
@@ -13,18 +13,27 @@ import { useMutateSchedule } from '@/hooks/useMutateSchedule';
 
 import { IoChevronBackSharp, IoChevronForwardSharp } from 'react-icons/io5';
 import { Button } from '@nextui-org/react';
+import { getRoomParticipantNumber } from '@/api/supabaseCSR/supabase';
 
 const WEEKDAYS = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
 
 const Calender = () => {
   const { id: userId }: { id: string } = useQueryUser();
   const { id: roomId }: { id: string } = useParams();
+  const [participantNumber, setParticipantNumber] = useState(1);
 
   const [nowDate, setNowDate] = useState<Date>(new Date());
   const { userSchedules, mySchedules, scheduleRange } = useSubscribeCalendar(roomId, userId);
   const { insertSchedule, deleteSchedule } = useMutateSchedule(roomId);
   const selectedDates = mySchedules.map((schedule) => new Date(schedule.start_date as string));
 
+  useEffect(() => {
+    const fetchData = async () => {
+      const number = await getRoomParticipantNumber(roomId);
+      setParticipantNumber(number);
+    };
+    fetchData();
+  }, []);
   useEffect(() => {
     if (scheduleRange?.start_date) {
       setNowDate(new Date(scheduleRange.start_date));
@@ -98,6 +107,7 @@ const Calender = () => {
               userSchedules={userSchedules}
               handleDateClick={handleDateClick}
               checkInRange={checkInRange}
+              participantNumber={participantNumber}
             />
           </div>
         </div>

--- a/src/components/room/calender/Calender.tsx
+++ b/src/components/room/calender/Calender.tsx
@@ -73,7 +73,7 @@ const Calender = () => {
             <Button isIconOnly onPress={prevMonth} className={styles.calendar_month_controller}>
               <IoChevronBackSharp />
             </Button>
-            <div className={styles.calendar_month}>{`${nowDate.getFullYear()}-${nowDate.getMonth() + 1}`}</div>
+            <span className={styles.calendar_month}>{`${nowDate.getFullYear()}-${nowDate.getMonth() + 1}`}</span>
             <Button isIconOnly onPress={afterMonth} className={styles.calendar_month_controller}>
               <IoChevronForwardSharp />
             </Button>

--- a/src/components/room/calender/EntireOfMonth.module.css
+++ b/src/components/room/calender/EntireOfMonth.module.css
@@ -55,3 +55,7 @@
 .none {
   color: #ccc;
 }
+
+.selected {
+  color: white;
+}

--- a/src/components/room/calender/EntireOfMonth.module.css
+++ b/src/components/room/calender/EntireOfMonth.module.css
@@ -21,7 +21,6 @@
 
 .disabled {
   color: #ccc !important;
-  cursor: default;
 }
 
 .abled {

--- a/src/components/room/calender/EntireOfMonth.module.css
+++ b/src/components/room/calender/EntireOfMonth.module.css
@@ -58,4 +58,5 @@
 
 .selected {
   color: white;
+  font-weight: 500;
 }

--- a/src/components/room/calender/EntireOfMonth.tsx
+++ b/src/components/room/calender/EntireOfMonth.tsx
@@ -28,7 +28,7 @@ const EntireOfMonth: React.FC<Props> = ({ nowDate, selectedDate, userSchedules, 
           {week.map((day) => (
             <li key={day.toISOString()} className={`${styles.days}  `} onClick={() => handleDateClick(day)}>
               <span
-                className={`${styles[dayColors(nowDate, day)]} ${!checkInRange(day) ? styles.disabled : styles.abled}`}
+                className={`${styles[dayColors(nowDate, day)]} ${checkInRange(day) ? styles.abled : styles.disabled}`}
               >
                 {day.getDate()}
               </span>

--- a/src/components/room/calender/EntireOfMonth.tsx
+++ b/src/components/room/calender/EntireOfMonth.tsx
@@ -6,6 +6,7 @@ import { Schedules } from './Schedules/Schedules';
 
 import dayColors from '@/utils/calendar/dayColors';
 import styles from './EntireOfMonth.module.css';
+import { checkIsSelectedDate } from '@/utils/calendar/checkIsSelectedDate';
 
 export type UserSchedule = Tables<'room_schedule'>;
 
@@ -34,9 +35,11 @@ const EntireOfMonth: React.FC<Props> = ({
         //  주 단위로 UI를 그린다.
         <ul key={index} className={styles.day_container}>
           {week.map((day) => (
-            <li key={day.toISOString()} className={`${styles.days}  `} onClick={() => handleDateClick(day)}>
+            <li key={day.toISOString()} className={`${styles.days}`} onClick={() => handleDateClick(day)}>
               <span
-                className={`${styles[dayColors(nowDate, day)]} ${checkInRange(day) ? styles.abled : styles.disabled}`}
+                className={`${styles[dayColors(nowDate, day)]} ${checkInRange(day) ? styles.abled : styles.disabled} ${
+                  checkIsSelectedDate({ selectedDate, day }) ? styles.selected : ''
+                }`}
               >
                 {day.getDate()}
               </span>

--- a/src/components/room/calender/EntireOfMonth.tsx
+++ b/src/components/room/calender/EntireOfMonth.tsx
@@ -13,11 +13,19 @@ type Props = {
   nowDate: Date;
   selectedDate: Date[];
   userSchedules: UserSchedule[];
+  participantNumber: number;
   handleDateClick: (date: Date) => void;
   checkInRange: (date: Date) => boolean;
 };
 
-const EntireOfMonth: React.FC<Props> = ({ nowDate, selectedDate, userSchedules, handleDateClick, checkInRange }) => {
+const EntireOfMonth: React.FC<Props> = ({
+  nowDate,
+  selectedDate,
+  userSchedules,
+  handleDateClick,
+  checkInRange,
+  participantNumber
+}) => {
   //  entireOfMonth에는 달력에 표시되는 날짜들이 주 단위로 배열에 나뉘어 들어가있다.
   const entireOfMonth = calculateOfMonth(nowDate);
   return (
@@ -32,7 +40,12 @@ const EntireOfMonth: React.FC<Props> = ({ nowDate, selectedDate, userSchedules, 
               >
                 {day.getDate()}
               </span>
-              <Schedules userSchedules={userSchedules} selectedDate={selectedDate} day={day} />
+              <Schedules
+                participantNumber={participantNumber}
+                userSchedules={userSchedules}
+                selectedDate={selectedDate}
+                day={day}
+              />
             </li>
           ))}
         </ul>

--- a/src/components/room/calender/EntireOfMonth.tsx
+++ b/src/components/room/calender/EntireOfMonth.tsx
@@ -37,6 +37,7 @@ const EntireOfMonth: React.FC<Props> = ({
           {week.map((day) => (
             <li key={day.toISOString()} className={`${styles.days}`} onClick={() => handleDateClick(day)}>
               <span
+                style={{ zIndex: 9999 }}
                 className={`${styles[dayColors(nowDate, day)]} ${checkInRange(day) ? styles.abled : styles.disabled} ${
                   checkIsSelectedDate({ selectedDate, day }) ? styles.selected : ''
                 }`}

--- a/src/components/room/calender/EntireOfMonth.tsx
+++ b/src/components/room/calender/EntireOfMonth.tsx
@@ -27,11 +27,11 @@ const EntireOfMonth: React.FC<Props> = ({ nowDate, selectedDate, userSchedules, 
         <ul key={index} className={styles.day_container}>
           {week.map((day) => (
             <li key={day.toISOString()} className={`${styles.days}  `} onClick={() => handleDateClick(day)}>
-              <p
+              <span
                 className={`${styles[dayColors(nowDate, day)]} ${!checkInRange(day) ? styles.disabled : styles.abled}`}
               >
                 {day.getDate()}
-              </p>
+              </span>
               <Schedules userSchedules={userSchedules} selectedDate={selectedDate} day={day} />
             </li>
           ))}

--- a/src/components/room/calender/Schedules/Schedules.tsx
+++ b/src/components/room/calender/Schedules/Schedules.tsx
@@ -11,9 +11,9 @@ type Props = {
 
 export const Schedules: React.FC<Props> = ({ userSchedules, selectedDate, day, participantNumber }) => {
   return (
-    <>
+    <span style={{ zIndex: '0' }}>
       <SchedulesOfMe selectedDate={selectedDate} day={day} />
       <SchedulesOfUsers userSchedules={userSchedules} day={day} participantNumber={participantNumber} />
-    </>
+    </span>
   );
 };

--- a/src/components/room/calender/Schedules/Schedules.tsx
+++ b/src/components/room/calender/Schedules/Schedules.tsx
@@ -6,13 +6,14 @@ type Props = {
   userSchedules: UserSchedule[];
   selectedDate: Date[];
   day: Date;
+  participantNumber: number;
 };
 
-export const Schedules: React.FC<Props> = ({ userSchedules, selectedDate, day }) => {
+export const Schedules: React.FC<Props> = ({ userSchedules, selectedDate, day, participantNumber }) => {
   return (
     <>
       <SchedulesOfMe selectedDate={selectedDate} day={day} />
-      <SchedulesOfUsers userSchedules={userSchedules} day={day} />
+      <SchedulesOfUsers userSchedules={userSchedules} day={day} participantNumber={participantNumber} />
     </>
   );
 };

--- a/src/components/room/calender/Schedules/SchedulesOfMe/SchedulesOfMe.module.css
+++ b/src/components/room/calender/Schedules/SchedulesOfMe/SchedulesOfMe.module.css
@@ -1,7 +1,7 @@
 .selected_date_circle {
   width: 35px;
   height: 35px;
-  background-color: #016e9c5a;
+  background-color: #016e9c;
   border-radius: 50%;
   position: absolute;
   top: 48%;

--- a/src/components/room/calender/Schedules/SchedulesOfMe/SchedulesOfMe.module.css
+++ b/src/components/room/calender/Schedules/SchedulesOfMe/SchedulesOfMe.module.css
@@ -4,7 +4,7 @@
   background-color: #016e9c5a;
   border-radius: 50%;
   position: absolute;
-  top: 50%;
+  top: 48%;
   left: 50%;
   transform: translate(-50%, -50%);
   cursor: pointer;

--- a/src/components/room/calender/Schedules/SchedulesOfMe/SchedulesOfMe.module.css
+++ b/src/components/room/calender/Schedules/SchedulesOfMe/SchedulesOfMe.module.css
@@ -1,11 +1,12 @@
 .selected_date_circle {
   width: 35px;
   height: 35px;
-  background-color: #016e9c;
+  background-color: #5074c1;
   border-radius: 50%;
   position: absolute;
   top: 48%;
   left: 50%;
   transform: translate(-50%, -50%);
   cursor: pointer;
+  z-index: 9;
 }

--- a/src/components/room/calender/Schedules/SchedulesOfUsers/SchedulesOfUsers.module.css
+++ b/src/components/room/calender/Schedules/SchedulesOfUsers/SchedulesOfUsers.module.css
@@ -1,7 +1,6 @@
 .selected_date_circle_of_users {
   width: 35px;
   height: 35px;
-  background-color: #35017621;
   border-radius: 50%;
   position: absolute;
   top: 48%;

--- a/src/components/room/calender/Schedules/SchedulesOfUsers/SchedulesOfUsers.module.css
+++ b/src/components/room/calender/Schedules/SchedulesOfUsers/SchedulesOfUsers.module.css
@@ -4,7 +4,7 @@
   background-color: #35017621;
   border-radius: 50%;
   position: absolute;
-  top: 50%;
+  top: 48%;
   left: 50%;
   transform: translate(-50%, -50%);
 }

--- a/src/components/room/calender/Schedules/SchedulesOfUsers/SchedulesOfUsers.tsx
+++ b/src/components/room/calender/Schedules/SchedulesOfUsers/SchedulesOfUsers.tsx
@@ -6,15 +6,21 @@ import type { UserSchedule } from '../../EntireOfMonth';
 type Props = {
   userSchedules: UserSchedule[];
   day: Date;
+  participantNumber: number;
 };
 
-const SchedulesOfUsers: React.FC<Props> = ({ userSchedules, day }) => {
+const SchedulesOfUsers: React.FC<Props> = ({ userSchedules, day, participantNumber }) => {
+  const opacity = 100 / participantNumber;
   return (
     <>
       {userSchedules.map((schedule, index) => {
         return (
           isSameDay(new Date(String(schedule.start_date)), day) && (
-            <span key={index} className={styles.selected_date_circle_of_users}></span>
+            <span
+              key={index}
+              className={styles.selected_date_circle_of_users}
+              style={{ backgroundColor: `rgba(53, 1, 118, ${opacity / 100})` }}
+            ></span>
           )
         );
       })}

--- a/src/components/room/sidebar/MyRooms.tsx
+++ b/src/components/room/sidebar/MyRooms.tsx
@@ -16,7 +16,7 @@ const MyRooms = () => {
     <ul className={styles.rooms}>
       {myRooms.map((room) => (
         <li key={room.id} className={styles.room} onClick={() => handleClickRoom(room.id)}>
-          {room.name}
+          {room.name?.[0]}
         </li>
       ))}
       <li className={styles.new_room}>

--- a/src/components/room/sidebar/Sidebar.tsx
+++ b/src/components/room/sidebar/Sidebar.tsx
@@ -11,7 +11,9 @@ const Sidebar = () => {
   return (
     <aside className={styles.aside}>
       <nav className={styles.channel}>
-        <Image src="/images/logo.png" />
+        <Link href="/" title="홈페이지로 가자올">
+          <Image src="/images/logo.png" />
+        </Link>
         <MyRooms />
         <div className={styles.profile}>
           <UserProfile />

--- a/src/hooks/useSubscribeCalendar.ts
+++ b/src/hooks/useSubscribeCalendar.ts
@@ -17,22 +17,9 @@ export const useSubscribeCalendar = (roomId: string, userId: string) => {
       .channel('schedule')
       .on(
         'postgres_changes',
-        { event: 'INSERT', schema: 'public', table: 'room_schedule', filter: `room_id=eq.${roomId}` },
-        (payload) => {
-          const updatedSchedule = payload.new as UserSchedule;
-          queryClient.setQueryData(['room-user-schedules', roomId], (prevData: UserSchedule[]) => {
-            return [...prevData, updatedSchedule];
-          });
-        }
-      )
-      .on(
-        'postgres_changes',
-        { event: 'DELETE', schema: 'public', table: 'room_schedule', filter: `room_id=eq.${roomId}` },
-        async (payload) => {
-          const deletedScheduleId = payload.old.id;
-          queryClient.setQueryData(['room-user-schedules', roomId], (prevData: UserSchedule[]) => {
-            return prevData.filter((schedule) => schedule.id !== deletedScheduleId);
-          });
+        { event: '*', schema: 'public', table: 'room_schedule', filter: `room_id=eq.${roomId}` },
+        (_payload) => {
+          queryClient.invalidateQueries({ queryKey: ['room-user-schedules', roomId] });
         }
       )
       .subscribe();

--- a/src/utils/calendar/checkIsSelectedDate.ts
+++ b/src/utils/calendar/checkIsSelectedDate.ts
@@ -1,0 +1,5 @@
+import { isSameDay } from 'date-fns';
+
+export const checkIsSelectedDate = ({ selectedDate, day }: { selectedDate: Date[]; day: Date }) => {
+  return selectedDate.some((date) => isSameDay(date, day));
+};


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 캘린더 헤더 정렬 변경 
- [x] 태그 이름들을 적정하게 수정
- [x] 월 표기 방식을 두자리수로 설정, 해당 로직에 대한 함수 작성
- [x] 달력 헤더의 년-월 텍스트 띄워져 있는 문제 해결
- [x] 내 일정 및 다른 유저 일정 표시 동그라미 위치 가운데로 수정
- [x] 다른 유저 일정이 표시될 때, 인원수별로 표시되는 색상 범위 수정 및 max 색상 고정
(방에 참여한 유저 인원수별로 투명도 조절했습니다)
- [x] 캘린더 일정 취소(삭제) 실시간으로 반영되도록 수정
- [x] 유저가 설정한 날짜 표시 스타일 변경
- [x] 사이드바에 표시되는 각 방의 이름을 첫 글자로만 표시
- [x] 사이드바 상단 로고 클릭 시 홈페이지로 이동 구현

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
전반적인 달력의 css를 변경하였고, 유저가 선택한 날짜 표시와 다른 유저들이 선택한 일정에 대한 표시 방식에 조금의 변형을 주었습니다.
또, 사이드바 상단 로고 클릭 시 홈페이지로 이동하도록 하였으며, 각 방의 이름을 첫 글자로만 표시하였습니다.

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
방에 참여한 유저 인원수별로 투명도 조절하는 로직에서, 방에 참여하는 유저 인원을 실시간으로 설정해주고 싶은데 (실시간으로 css도 바뀌도록) 어떻게 해야할까요?
+유저 인원에 따라 다른 컴포넌트들도 같이 리랜더링 되어야하므로 props drilling을 사용하였습니다.

## 📸 스크린샷(선택)
![화면 기록 2024-04-22 오후 6 02 39](https://github.com/where-we-meet/owl/assets/69431340/2e8c6854-9566-409b-a520-7cf735360033)
