### PR TITLE
[Feat] room페이지로 로직을 이동시키고 채팅에 리얼타임을 적용시켰습니다.

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -42,6 +42,12 @@ export const getMessageData = async (roomId: string) => {
   return data;
 };
 
+export const getMessages = async (roomId: string) => {
+  const { data, error } = await supabase.from('message').select('*').eq('room_Id', roomId);
+  if (error) throw error;
+  return data;
+};
+
 export const getUsersData = async (userId: string) => {
   const { data, error } = await supabase.from('users').select('*').eq('id', userId);
   if (error) throw error;

--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -36,8 +36,8 @@ export const getUserSchedule = async (roomId: string) => {
 //   return data;
 // };
 
-export const getMessageData = async (userId: string) => {
-  const { data, error } = await supabase.from('message').select('*, users(*)');
+export const getMessageData = async (roomId: string) => {
+  const { data, error } = await supabase.from('message').select('*, users(*)').eq('room_id', roomId);
   if (error) throw error;
   return data;
 };

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -6,7 +6,7 @@ import { FaGithub } from 'react-icons/fa6';
 import owl_image from '../../../public/images/about_owl_image.jpg';
 import Header from '@/components/header/Header';
 import Footer from '@/components/Footer';
-import { ChatRoom } from '@/components/room/chatRoom/ChatRoom';
+
 export default function AboutPage() {
   return (
     <>
@@ -89,7 +89,6 @@ export default function AboutPage() {
             </div>
           </div>
         </section>
-        <ChatRoom />
         <PayPalDonate />
       </main>
       <Footer />

--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -8,6 +8,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getRoomIsConfirmed } from '@/api/room';
 import styles from './page.module.css';
+import { ChatRoom } from '@/components/room/chatRoom/ChatRoom';
 
 const SettingPage = () => {
   const router = useRouter();
@@ -31,6 +32,7 @@ const SettingPage = () => {
       <section className={styles.map}>
         <SettingMap />
       </section>
+      <ChatRoom roomId={roomId} />
     </div>
   );
 };

--- a/src/components/room/chatRoom/ChatMessage.tsx
+++ b/src/components/room/chatRoom/ChatMessage.tsx
@@ -1,18 +1,26 @@
-'use client';
-import { Suspense } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import { ListMessage } from './ListMessage';
 import { InitMessages } from './InitMessages';
 import { getMessageData } from '@/api/supabaseCSR/supabase';
 import { useQueryUser } from '@/hooks/useQueryUser';
+import { IMessage } from '@/store/messageStore';
 
-export const ChatMessage = async () => {
+export const ChatMessage = ({ roomId }: { roomId: string }) => {
   const user = useQueryUser();
-  const data = await getMessageData(user.id);
+  const [userData, setUserData] = useState<IMessage[]>([]);
+
+  useEffect(() => {
+    const messages = async () => {
+      const messageData = await getMessageData(user.id);
+      setUserData(messageData);
+    };
+    messages();
+  }, []);
 
   return (
     <Suspense fallback={'loading..'}>
-      <ListMessage />
-      <InitMessages messages={data || []} />
+      <ListMessage roomId={roomId} />
+      <InitMessages messages={userData || []} />
     </Suspense>
   );
 };

--- a/src/components/room/chatRoom/ChatMessage.tsx
+++ b/src/components/room/chatRoom/ChatMessage.tsx
@@ -2,17 +2,15 @@ import { Suspense, useEffect, useState } from 'react';
 import { ListMessage } from './ListMessage';
 import { InitMessages } from './InitMessages';
 import { getMessageData } from '@/api/supabaseCSR/supabase';
-import { useQueryUser } from '@/hooks/useQueryUser';
 import { IMessage } from '@/store/messageStore';
 
 export const ChatMessage = ({ roomId }: { roomId: string }) => {
-  const user = useQueryUser();
-  const [userData, setUserData] = useState<IMessage[]>([]);
+  const [messages, setMessages] = useState<IMessage[]>([]);
 
   useEffect(() => {
     const messages = async () => {
-      const messageData = await getMessageData(user.id);
-      setUserData(messageData);
+      const messageData = await getMessageData(roomId);
+      setMessages(messageData);
     };
     messages();
   }, []);
@@ -20,7 +18,7 @@ export const ChatMessage = ({ roomId }: { roomId: string }) => {
   return (
     <Suspense fallback={'loading..'}>
       <ListMessage roomId={roomId} />
-      <InitMessages messages={userData || []} />
+      <InitMessages messages={messages || []} />
     </Suspense>
   );
 };

--- a/src/components/room/chatRoom/ChatRoom.tsx
+++ b/src/components/room/chatRoom/ChatRoom.tsx
@@ -1,13 +1,31 @@
+'use client';
 import { ChatMessage } from './ChatMessage';
 import { InputBox } from './InputBox';
+import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button, useDisclosure } from '@nextui-org/react';
 
-export const ChatRoom = () => {
+export const ChatRoom = ({ roomId }: { roomId: string }) => {
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
   return (
-    <main>
-      <ChatMessage />
-      <div>
-        <InputBox />
-      </div>
-    </main>
+    <>
+      <Button onPress={onOpen}>Open Modal</Button>
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={false}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader>룸 채팅방</ModalHeader>
+              <ModalBody>
+                <main>
+                  <ChatMessage roomId={roomId} />
+                  <div>
+                    <InputBox roomId={roomId} />
+                  </div>
+                </main>
+              </ModalBody>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
   );
 };

--- a/src/components/room/chatRoom/InitMessages.tsx
+++ b/src/components/room/chatRoom/InitMessages.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { IMessage, useMessage } from '@/store/messageStore';
+import { IMessage, useMessageStore } from '@/store/messageStore';
 import { useEffect, useRef } from 'react';
 
 export const InitMessages = ({ messages }: { messages: IMessage[] }) => {
@@ -7,7 +7,7 @@ export const InitMessages = ({ messages }: { messages: IMessage[] }) => {
 
   useEffect(() => {
     if (!initState.current) {
-      useMessage.setState({ messages });
+      useMessageStore.setState({ messages });
     }
     initState.current = true;
   }, []);

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -3,13 +3,13 @@
 import { createClient } from '@/utils/supabase/client';
 import styles from './InputBox.module.css';
 import { useQueryUser } from '@/hooks/useQueryUser';
-import { useMessage } from '@/store/messageStore';
+import { useMessageStore } from '@/store/messageStore';
 import { useQueryUsersData } from '@/hooks/useQueryUsersData';
 
 export const InputBox = ({ roomId }: { roomId: string }) => {
   const supabase = createClient();
   const user = useQueryUser();
-  const addMessage = useMessage((state) => state.addMessage);
+  const addMessage = useMessageStore((state) => state.addMessage);
 
   const { data: userData } = useQueryUsersData(user.id);
 

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -6,7 +6,7 @@ import { useQueryUser } from '@/hooks/useQueryUser';
 import { useMessage } from '@/store/messageStore';
 import { useQueryUsersData } from '@/hooks/useQueryUsersData';
 
-export const InputBox = () => {
+export const InputBox = ({ roomId }: { roomId: string }) => {
   const supabase = createClient();
   const user = useQueryUser();
   const addMessage = useMessage((state) => state.addMessage);
@@ -23,6 +23,7 @@ export const InputBox = () => {
       send_by: user.id,
       is_edit: false,
       created_at: new Date().toISOString(),
+      room_id: roomId,
       users: {
         id: userData[0].id,
         profile_url: userData[0].profile_url,
@@ -30,10 +31,9 @@ export const InputBox = () => {
         created_at: userData[0].created_at
       }
     };
-
     addMessage(newMessage);
 
-    const { data, error } = await supabase.from('message').insert({ text });
+    const { data, error } = await supabase.from('message').insert({ text, room_id: roomId });
 
     if (error) throw error;
     return data;

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -14,30 +14,29 @@ export const InputBox = () => {
   const { data: userData } = useQueryUsersData(user.id);
 
   const handleSendMessage = async (text: string) => {
-    if (text.trim() && userData) {
-      const newMessage = {
-        id: crypto.randomUUID(),
-        text,
-        send_by: user.id,
-        is_edit: false,
-        created_at: new Date().toISOString(),
-        users: {
-          id: userData[0].id,
-          profile_url: userData[0].profile_url,
-          name: userData[0].name,
-          created_at: userData[0].created_at
-        }
-      };
-
-      addMessage(newMessage);
-
-      const { data, error } = await supabase.from('message').insert({ text });
-
-      if (error) throw error;
-      return data;
-    } else {
-      console.error('빈칸 금지관련 에러를 출력합시다');
+    if (!text.trim() && !userData) {
+      return;
     }
+    const newMessage = {
+      id: crypto.randomUUID(),
+      text,
+      send_by: user.id,
+      is_edit: false,
+      created_at: new Date().toISOString(),
+      users: {
+        id: userData[0].id,
+        profile_url: userData[0].profile_url,
+        name: userData[0].name,
+        created_at: userData[0].created_at
+      }
+    };
+
+    addMessage(newMessage);
+
+    const { data, error } = await supabase.from('message').insert({ text });
+
+    if (error) throw error;
+    return data;
   };
 
   return (

--- a/src/components/room/chatRoom/ListMessage.tsx
+++ b/src/components/room/chatRoom/ListMessage.tsx
@@ -1,9 +1,31 @@
+'use client';
 import styles from './ListMessage.module.css';
-import { useMessage } from '@/store/messageStore';
+import { IMessage, useMessage } from '@/store/messageStore';
 import { Message } from './Message';
+import { useEffect } from 'react';
+import { createClient } from '@/utils/supabase/client';
 
-export const ListMessage = () => {
-  const messages = useMessage((state) => state.messages);
+export const ListMessage = ({ roomId }: { roomId: string }) => {
+  const supabase = createClient();
+  const { messages, addMessage } = useMessage((state) => state);
+
+  useEffect(() => {
+    const channel = supabase
+      .channel('chatMessage')
+      .on(
+        'postgres_changes',
+        { event: 'INSERT', schema: 'public', table: 'message', filter: `room_id=eq.${roomId}` },
+        (payload) => {
+          const newMessage = payload.new as IMessage;
+          addMessage(newMessage);
+        }
+      )
+      .subscribe();
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [supabase]);
 
   return (
     <section className={styles.container}>

--- a/src/components/room/chatRoom/ListMessage.tsx
+++ b/src/components/room/chatRoom/ListMessage.tsx
@@ -1,13 +1,15 @@
 'use client';
 import styles from './ListMessage.module.css';
-import { IMessage, useMessage } from '@/store/messageStore';
+import { IMessage, useMessageStore } from '@/store/messageStore';
 import { Message } from './Message';
 import { useEffect } from 'react';
 import { createClient } from '@/utils/supabase/client';
+import { useQueryClient } from '@tanstack/react-query';
 
 export const ListMessage = ({ roomId }: { roomId: string }) => {
   const supabase = createClient();
-  const { messages, addMessage } = useMessage((state) => state);
+  const queryClient = useQueryClient();
+  const { messages, addMessage } = useMessageStore((state) => state);
 
   useEffect(() => {
     const channel = supabase

--- a/src/components/room/chatRoom/Message.module.css
+++ b/src/components/room/chatRoom/Message.module.css
@@ -21,6 +21,13 @@
   flex-direction: column;
 }
 
+.chat_info {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
 .user_info {
   display: flex;
   flex-direction: row;

--- a/src/components/room/chatRoom/Message.tsx
+++ b/src/components/room/chatRoom/Message.tsx
@@ -1,5 +1,4 @@
 import { IMessage } from '@/store/messageStore';
-import Image from 'next/image';
 import styles from './Message.module.css';
 
 export const Message = ({ message }: { message: IMessage }) => {

--- a/src/components/room/chatRoom/Message.tsx
+++ b/src/components/room/chatRoom/Message.tsx
@@ -1,4 +1,7 @@
+'use client';
 import { IMessage } from '@/store/messageStore';
+import { Dropdown, DropdownTrigger, DropdownMenu, DropdownSection, DropdownItem, Button } from '@nextui-org/react';
+import { IoIosMore } from 'react-icons/io';
 import styles from './Message.module.css';
 
 export const Message = ({ message }: { message: IMessage }) => {
@@ -15,13 +18,34 @@ export const Message = ({ message }: { message: IMessage }) => {
           />
         </div>
         <div className={styles.content}>
-          <div className={styles.user_info}>
-            <h3 className={styles.name}>{message.users?.name}</h3>
-            <h3 className={styles.date_time}>{new Date(message.created_at).toDateString()}</h3>
+          <div className={styles.chat_info}>
+            <div className={styles.user_info}>
+              <h3 className={styles.name}>{message.users?.name}</h3>
+              <h3 className={styles.date_time}>{new Date(message.created_at).toDateString()}</h3>
+            </div>
+            <MessageMenu />
           </div>
           <p className={styles.chat_log}>{message.text}</p>
         </div>
       </figure>
     </div>
+  );
+};
+
+export const MessageMenu = () => {
+  return (
+    <Dropdown>
+      <DropdownTrigger>
+        <Button variant="bordered">
+          <IoIosMore />
+        </Button>
+      </DropdownTrigger>
+      <DropdownMenu aria-label="Static Actions">
+        <DropdownItem key="edit">수정</DropdownItem>
+        <DropdownItem key="delete" className="text-danger" color="danger">
+          삭제
+        </DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
   );
 };

--- a/src/store/messageStore.ts
+++ b/src/store/messageStore.ts
@@ -6,6 +6,7 @@ export type IMessage = {
   is_edit: boolean | null;
   send_by: string;
   text: string | null;
+  room_id: string | null;
   users: {
     created_at: string;
     id: string;

--- a/src/store/messageStore.ts
+++ b/src/store/messageStore.ts
@@ -20,7 +20,7 @@ type Message = {
   addMessage: (message: IMessage) => void;
 };
 
-export const useMessage = create<Message>()((set) => ({
+export const useMessageStore = create<Message>()((set) => ({
   messages: [],
   addMessage: (message) => set((state) => ({ messages: [...state.messages, message] }))
 }));

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -14,6 +14,7 @@ export type Database = {
           created_at: string
           id: string
           is_edit: boolean | null
+          room_id: string | null
           send_by: string
           text: string | null
         }
@@ -21,6 +22,7 @@ export type Database = {
           created_at?: string
           id?: string
           is_edit?: boolean | null
+          room_id?: string | null
           send_by?: string
           text?: string | null
         }
@@ -28,10 +30,18 @@ export type Database = {
           created_at?: string
           id?: string
           is_edit?: boolean | null
+          room_id?: string | null
           send_by?: string
           text?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "public_message_room_id_fkey"
+            columns: ["room_id"]
+            isOneToOne: false
+            referencedRelation: "rooms"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "public_message_send_by_fkey"
             columns: ["send_by"]


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#260 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 채팅룸의 기본 상태를 zustand로 관리
- [x] 채팅룸의 테이블을 생성, 해당 테이블에 추가되는 로직을 구현
- [x] 채팅룸의 데이터가 DB로부터 올바르게 수신되는 지 확인
- [x] 채팅룸의 데이터를 realtime으로 구현
- [ ] 채팅룸의 채팅을 수정 할 수 있는 기능을 추가
- [ ] 채팅룸의 채팅을 삭제 ( deleted ) 할 수 있는 기능을 추가

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
각 방마다 채팅정보를 받아오기 위해서 로직을 room 페이지로 이동시켰습니다.
현재 room내부에 한 자리를 차지하고 있기 때문에, 다른 로직을 적용할 시에 chatRoom 컴포넌트를 주석처리 해주세요.
realtime으로 받아오는 로직은 수행되고 있으나, 본인의 자료까지 보이기 때문에 추가 수정이 필요합니다.

모달창을 여닫을 때 데이터를 불러오는 로직을 보완해야합니다 ( 현재 출력이 안되고 있음 )

```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
1. room으로 이동 후 room_id를 함께 저장하려고 했을 때상태를 수정하는 올바르게 DB에 등록되지 않는 부분이 부분에서 문제가 발생했습니다.
- 해당하는 페이지에 insert 값에 text와 room_id를 추가해주었습니다.

```
## 📸 스크린샷(선택)
![chatroom](https://github.com/where-we-meet/owl/assets/109938441/27e63012-4977-47f8-90a3-3c50c982031b)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->

1. 채팅이 룸에 귀속된 것인지 체크해야합니다. (다른 방에서 채팅을 칠 때 그 채팅이 보이는 지 확인용도)
2. 다른 유저가 채팅을 칠 때 확인이 되는 지 체크해야합니다. ( 잘 적용이 되는지 체크 )