### PR TITLE
[Feat] 모달창의 버튼 디자인, 위치와 닫힘형식을 개선하였습니다.

### DIFF
--- a/src/app/room/[id]/page.tsx
+++ b/src/app/room/[id]/page.tsx
@@ -43,8 +43,8 @@ const SettingPage = () => {
 
       <section className={styles.map}>
         <SettingMap isOpened={isOpened} />
+        <ChatRoom roomId={roomId} />
       </section>
-      <ChatRoom roomId={roomId} />
     </div>
   );
 };

--- a/src/components/room/chatRoom/ChatRoom.module.css
+++ b/src/components/room/chatRoom/ChatRoom.module.css
@@ -1,0 +1,12 @@
+.chatroom_modal {
+  position: fixed;
+  right: 6rem;
+  bottom: 6rem;
+  z-index: 99;
+}
+
+.modal_header {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}

--- a/src/components/room/chatRoom/ChatRoom.tsx
+++ b/src/components/room/chatRoom/ChatRoom.tsx
@@ -1,19 +1,38 @@
 'use client';
 import { ChatMessage } from './ChatMessage';
 import { InputBox } from './InputBox';
-import { Modal, ModalContent, ModalHeader, ModalBody, ModalFooter, Button, useDisclosure } from '@nextui-org/react';
+import { Modal, ModalContent, ModalHeader, ModalBody, Button, useDisclosure } from '@nextui-org/react';
+import { IoChatbubblesSharp } from 'react-icons/io5';
+import styles from './ChatRoom.module.css';
 
 export const ChatRoom = ({ roomId }: { roomId: string }) => {
-  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+  const { isOpen, onOpen, onClose, onOpenChange } = useDisclosure();
+
+  const handleModalControl = () => {
+    if (isOpen) {
+      onClose();
+    } else {
+      onOpen();
+    }
+  };
 
   return (
-    <>
-      <Button onPress={onOpen}>Open Modal</Button>
-      <Modal isOpen={isOpen} onOpenChange={onOpenChange} isDismissable={false}>
+    <div className={styles.chatroom_modal}>
+      <Button color="secondary" endContent={<IoChatbubblesSharp size="2rem" />} onPress={handleModalControl}>
+        대화하기
+      </Button>
+      <Modal
+        closeButton
+        size="3xl"
+        isOpen={isOpen}
+        onOpenChange={onOpenChange}
+        isDismissable={false}
+        isKeyboardDismissDisabled={false}
+      >
         <ModalContent>
-          {(onClose) => (
+          {() => (
             <>
-              <ModalHeader>룸 채팅방</ModalHeader>
+              <ModalHeader className={styles.modal_header}>룸 채팅방</ModalHeader>
               <ModalBody>
                 <main>
                   <ChatMessage roomId={roomId} />
@@ -26,6 +45,6 @@ export const ChatRoom = ({ roomId }: { roomId: string }) => {
           )}
         </ModalContent>
       </Modal>
-    </>
+    </div>
   );
 };

--- a/src/components/room/chatRoom/InputBox.module.css
+++ b/src/components/room/chatRoom/InputBox.module.css
@@ -1,4 +1,7 @@
 .input_box {
+  position: relative;
   display: flex;
-  width: 100vw;
+  width: 100%;
+  border: 2px solid gray;
+  resize: none;
 }

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -45,6 +45,7 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
         placeholder="send message"
         autoFocus={true}
         className={styles.input_box}
+        maxLength={120}
         onKeyDown={(e) => {
           if (e.key === 'Enter') {
             handleSendMessage(e.currentTarget.value);

--- a/src/components/room/chatRoom/ListMessage.module.css
+++ b/src/components/room/chatRoom/ListMessage.module.css
@@ -1,43 +1,4 @@
-.constainer {
-  width: 100vw;
-  height: 100%;
-  background-color: black;
-}
-
-.chatbox_body {
-  flex: 1;
-  height: auto;
-  background-color: rgb(49, 49, 49);
-}
-.profiles {
-  display: flex;
-  flex-direction: row;
-  padding: 1.2rem;
-  gap: 0.6rem;
-}
-
-.content {
-  display: flex;
-  flex-direction: column;
-}
-
-.user_info {
-  display: flex;
-  flex-direction: row;
-  gap: 0.6rem;
-}
-
-.name {
-  font-size: large;
-  font-weight: bold;
-  color: rgb(196, 196, 196);
-}
-
-.date_time {
-  font-size: small;
-  color: rgb(196, 196, 196);
-}
-
-.chat_log {
-  color: rgb(196, 196, 196);
+.container {
+  overflow-y: auto;
+  max-height: 500px;
 }

--- a/src/components/room/chatRoom/Message.tsx
+++ b/src/components/room/chatRoom/Message.tsx
@@ -1,7 +1,5 @@
 'use client';
 import { IMessage } from '@/store/messageStore';
-import { Dropdown, DropdownTrigger, DropdownMenu, DropdownSection, DropdownItem, Button } from '@nextui-org/react';
-import { IoIosMore } from 'react-icons/io';
 import styles from './Message.module.css';
 
 export const Message = ({ message }: { message: IMessage }) => {
@@ -23,29 +21,10 @@ export const Message = ({ message }: { message: IMessage }) => {
               <h3 className={styles.name}>{message.users?.name}</h3>
               <h3 className={styles.date_time}>{new Date(message.created_at).toDateString()}</h3>
             </div>
-            <MessageMenu />
           </div>
           <p className={styles.chat_log}>{message.text}</p>
         </div>
       </figure>
     </div>
-  );
-};
-
-export const MessageMenu = () => {
-  return (
-    <Dropdown>
-      <DropdownTrigger>
-        <Button variant="bordered">
-          <IoIosMore />
-        </Button>
-      </DropdownTrigger>
-      <DropdownMenu aria-label="Static Actions">
-        <DropdownItem key="edit">수정</DropdownItem>
-        <DropdownItem key="delete" className="text-danger" color="danger">
-          삭제
-        </DropdownItem>
-      </DropdownMenu>
-    </Dropdown>
   );
 };

--- a/src/components/room/header/RoomHeader.tsx
+++ b/src/components/room/header/RoomHeader.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getRoomData } from '@/api/supabaseCSR/supabase';
 import ConfirmedButton from '../ConfirmedButton';
 import styles from './RoomHeader.module.css';
+import { ChatRoom } from '../chatRoom/ChatRoom';
 
 const RoomHeader = () => {
   const { id: roomId }: { id: string } = useParams();


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #260
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 채팅룸의 기본 상태를 zustand로 관리
- [x] 채팅룸의 테이블을 생성, 해당 테이블에 추가되는 로직을 구현
- [x] 채팅룸의 데이터가 DB로부터 올바르게 수신되는 지 확인
- [x] 채팅룸의 데이터를 realtime으로 구현

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
채팅 룸 내부의 모달창의 위치와, 모달 닫힘 방식을 개선했습니다.
모달 창은 우 하단에 존재하며 키 컬러인 보라색으로 삼았습니다.
또한 모달창 버튼을 상호작용하여 채팅을 여닫을 수 있고, esc 키와, x버튼을 통해 닫을 수 있습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
Next UI에서 제공하는 모달창은 지정된 커스텀만이 가능한데 
useDisclosure 내부에 존재하는 onOpenChange의 변수로는 버튼 토글을 구현 할 수 없었습니다. 
- 대신 onOpen과 onClose 를 통한 if문 분기처리를 통해 구현할 수 있었습니다.
```
## 📸 스크린샷(선택)
![chatroom_with_modal](https://github.com/where-we-meet/owl/assets/109938441/28a39da9-798d-42da-aedb-ad50042b2638)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->

실시간 채팅이 되는 것과, 최초 실행시 딜레이가 길다면 스피너 혹은 스켈레톤UI 사용을 고려해봄직합니다.