### PR TITLE
[style/show center] 중심 위치 주소를 타이틀에 표시, 안내 문구 추가

### DIFF
--- a/src/components/room/calender/ResetSchedule/ResetSchedule.tsx
+++ b/src/components/room/calender/ResetSchedule/ResetSchedule.tsx
@@ -16,7 +16,7 @@ const ResetSchedule = () => {
 
   return (
     <Button isIconOnly>
-      <LuEraser style={{ cursor: 'pointer' }} onClick={handleResetSchedule} />
+      <LuEraser title="선택된 날짜를 초기화한다올" style={{ cursor: 'pointer' }} onClick={handleResetSchedule} />
     </Button>
   );
 };

--- a/src/components/room/header/RoomHeader.module.css
+++ b/src/components/room/header/RoomHeader.module.css
@@ -24,22 +24,20 @@
   flex-direction: column;
 }
 
-.title_container > p {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 .center_address {
-  margin: 0.9rem 0;
+  margin-top: 0.9rem;
 }
 
 .line {
   display: flex;
 
-  width: 59%;
-  height: 1%;
+  width: 10%;
+  height: 0.5px;
 
   margin: 0.3rem 0rem;
   background-color: white;
+}
+
+.center_address_copy {
+  margin-bottom: 0.5rem;
 }

--- a/src/components/room/header/RoomHeader.module.css
+++ b/src/components/room/header/RoomHeader.module.css
@@ -1,10 +1,13 @@
 .room_header {
+  padding: 0.8rem;
+
   display: flex;
   flex-direction: column;
-  padding: 0.8rem;
+
+  border-radius: 0.8rem;
+
   background-color: #4e4e4e;
   color: white;
-  border-radius: 0.8rem;
 }
 
 .room_header > div {
@@ -31,7 +34,7 @@
 .line {
   display: flex;
 
-  width: 10%;
+  width: 68%;
   height: 0.5px;
 
   margin: 0.3rem 0rem;

--- a/src/components/room/header/RoomHeader.module.css
+++ b/src/components/room/header/RoomHeader.module.css
@@ -31,5 +31,15 @@
 }
 
 .center_address {
-  margin: 0.75rem 0;
+  margin: 0.9rem 0;
+}
+
+.line {
+  display: flex;
+
+  width: 59%;
+  height: 1%;
+
+  margin: 0.3rem 0rem;
+  background-color: white;
 }

--- a/src/components/room/header/RoomHeader.tsx
+++ b/src/components/room/header/RoomHeader.tsx
@@ -3,12 +3,14 @@ import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getRoomData } from '@/api/supabaseCSR/supabase';
 import ConfirmedButton from '../ConfirmedButton';
+import { useSettingMap } from '@/hooks/useSettingMap';
 import styles from './RoomHeader.module.css';
-import { ChatRoom } from '../chatRoom/ChatRoom';
 
 const RoomHeader = () => {
   const { id: roomId }: { id: string } = useParams();
+  const { isPinned, halfwayPoint } = useSettingMap();
   const { data: room } = useQuery({ queryKey: ['room', roomId], queryFn: () => getRoomData(roomId) });
+
   return (
     <div className={styles.room_header}>
       <div>
@@ -19,7 +21,7 @@ const RoomHeader = () => {
           <ConfirmedButton />
         </div>
       </div>
-      <p className={styles.center_address}>중심 위치 주소를 보여줍니다.</p>
+      <p className={styles.center_address}>{isPinned ? isPinned : '중심 위치 주소를 보여줍니다.'}</p>
     </div>
   );
 };

--- a/src/components/room/header/RoomHeader.tsx
+++ b/src/components/room/header/RoomHeader.tsx
@@ -4,13 +4,19 @@ import { useQuery } from '@tanstack/react-query';
 import { getRoomData } from '@/api/supabaseCSR/supabase';
 import ConfirmedButton from '../ConfirmedButton';
 import { useMapController } from '@/hooks/useMapController';
+import { useQueryRoomUsers } from '@/hooks/useQueryRoomUsers';
+import { useQueryUser } from '@/hooks/useQueryUser';
 import styles from './RoomHeader.module.css';
 
 const RoomHeader = () => {
   const { id: roomId }: { id: string } = useParams();
+  const { id: userId } = useQueryUser();
   const { address } = useMapController();
+  const { roomUsers, isPending } = useQueryRoomUsers(roomId, userId);
   const { data: room } = useQuery({ queryKey: ['room', roomId], queryFn: () => getRoomData(roomId) });
-  console.log(location);
+
+  const participantNumber = roomUsers.length;
+
   return (
     <div className={styles.room_header}>
       <div>
@@ -21,7 +27,13 @@ const RoomHeader = () => {
           <ConfirmedButton />
         </div>
       </div>
-      <p className={styles.center_address}>{address ? address : '중심 위치 주소를 보여줍니다.'}</p>
+
+      <p className={styles.center_address}>
+        {' '}
+        <h2>중심 위치 주소</h2>
+        <span className={styles.line}></span>
+        {address ? address : '중심 위치 주소를 보여줍니다.'}
+      </p>
     </div>
   );
 };

--- a/src/components/room/header/RoomHeader.tsx
+++ b/src/components/room/header/RoomHeader.tsx
@@ -4,18 +4,13 @@ import { useQuery } from '@tanstack/react-query';
 import { getRoomData } from '@/api/supabaseCSR/supabase';
 import ConfirmedButton from '../ConfirmedButton';
 import { useMapController } from '@/hooks/useMapController';
-import { useQueryRoomUsers } from '@/hooks/useQueryRoomUsers';
-import { useQueryUser } from '@/hooks/useQueryUser';
 import styles from './RoomHeader.module.css';
 
 const RoomHeader = () => {
   const { id: roomId }: { id: string } = useParams();
-  const { id: userId } = useQueryUser();
-  const { address } = useMapController();
-  const { roomUsers, isPending } = useQueryRoomUsers(roomId, userId);
-  const { data: room } = useQuery({ queryKey: ['room', roomId], queryFn: () => getRoomData(roomId) });
 
-  const participantNumber = roomUsers.length;
+  const { address } = useMapController();
+  const { data: room } = useQuery({ queryKey: ['room', roomId], queryFn: () => getRoomData(roomId) });
 
   return (
     <div className={styles.room_header}>
@@ -28,12 +23,9 @@ const RoomHeader = () => {
         </div>
       </div>
 
-      <p className={styles.center_address}>
-        {' '}
-        <h2>중심 위치 주소</h2>
-        <span className={styles.line}></span>
-        {address ? address : '중심 위치 주소를 보여줍니다.'}
-      </p>
+      <p className={styles.center_address}>중심 위치 주소</p>
+      <span className={styles.line}></span>
+      <p className={styles.center_address_copy}>{address ? address : '중심 위치 주소를 보여줍니다.'}</p>
     </div>
   );
 };

--- a/src/components/room/header/RoomHeader.tsx
+++ b/src/components/room/header/RoomHeader.tsx
@@ -3,14 +3,14 @@ import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { getRoomData } from '@/api/supabaseCSR/supabase';
 import ConfirmedButton from '../ConfirmedButton';
-import { useSettingMap } from '@/hooks/useSettingMap';
+import { useMapController } from '@/hooks/useMapController';
 import styles from './RoomHeader.module.css';
 
 const RoomHeader = () => {
   const { id: roomId }: { id: string } = useParams();
-  const { isPinned, halfwayPoint } = useSettingMap();
+  const { address } = useMapController();
   const { data: room } = useQuery({ queryKey: ['room', roomId], queryFn: () => getRoomData(roomId) });
-
+  console.log(location);
   return (
     <div className={styles.room_header}>
       <div>
@@ -21,7 +21,7 @@ const RoomHeader = () => {
           <ConfirmedButton />
         </div>
       </div>
-      <p className={styles.center_address}>{isPinned ? isPinned : '중심 위치 주소를 보여줍니다.'}</p>
+      <p className={styles.center_address}>{address ? address : '중심 위치 주소를 보여줍니다.'}</p>
     </div>
   );
 };

--- a/src/components/room/place/StartLocationBox.module.css
+++ b/src/components/room/place/StartLocationBox.module.css
@@ -4,7 +4,7 @@
   width: 32%;
   min-width: 250px;
 
-  bottom: 15%;
+  bottom: 5%;
   left: calc(40% - 5rem);
 
   z-index: 13;

--- a/src/components/room/sidebar/MyRooms.tsx
+++ b/src/components/room/sidebar/MyRooms.tsx
@@ -20,7 +20,7 @@ const MyRooms = () => {
         </li>
       ))}
       <li className={styles.new_room}>
-        <Link href="/start">
+        <Link href="/start" title="새로운 모임방을 만들러 가자올">
           <BsPlusSquareDotted size="100%" />
         </Link>
       </li>

--- a/src/components/room/sidebar/Sidebar.module.css
+++ b/src/components/room/sidebar/Sidebar.module.css
@@ -70,6 +70,15 @@
   gap: 4px;
 }
 
+.select_date {
+  margin-left: 0.5rem;
+
+  display: flex;
+  align-items: center;
+
+  gap: 0.3rem;
+}
+
 .profile {
   display: flex;
   align-items: center;

--- a/src/components/room/sidebar/Sidebar.module.css
+++ b/src/components/room/sidebar/Sidebar.module.css
@@ -45,11 +45,29 @@
   height: 1rem;
 }
 
+.wrap {
+  display: flex;
+  margin-bottom: 0.5rem;
+
+  flex-direction: row;
+  justify-content: space-between;
+}
+
 .brand {
   padding: 0.2rem 0;
-  margin-bottom: 0.5rem;
+
   font-weight: bold;
   font-size: 1.5rem;
+}
+
+.participants {
+  display: flex;
+  align-items: center;
+
+  font-weight: bold;
+  font-size: 1.5rem;
+
+  gap: 4px;
 }
 
 .profile {

--- a/src/components/room/sidebar/Sidebar.tsx
+++ b/src/components/room/sidebar/Sidebar.tsx
@@ -5,9 +5,19 @@ import UserList from './user/UserList';
 import MyRooms from './MyRooms';
 import UserProfile from '@/components/header/profile/UserProfileButton';
 import LinkShare from '../share/LinkShare';
+import { useQueryUser } from '@/hooks/useQueryUser';
+import { useQueryRoomUsers } from '@/hooks/useQueryRoomUsers';
+import { useParams } from 'next/navigation';
+import { IoMdPerson } from 'react-icons/io';
 import styles from './Sidebar.module.css';
 
 const Sidebar = () => {
+  const { id: roomId }: { id: string } = useParams();
+  const { id: userId } = useQueryUser();
+  const { roomUsers, isPending } = useQueryRoomUsers(roomId, userId);
+
+  const participantNumber = roomUsers.length;
+
   return (
     <>
       <nav className={styles.channel}>
@@ -21,9 +31,17 @@ const Sidebar = () => {
       </nav>
 
       <div className={styles.room}>
-        <Link className={styles.brand} color="foreground" href="/">
-          OWL-LiNK
-        </Link>
+        <div className={styles.wrap}>
+          <Link className={styles.brand} color="foreground" href="/">
+            OWL-LiNK
+          </Link>
+
+          <p className={styles.participants}>
+            <IoMdPerson />
+            {participantNumber}
+          </p>
+        </div>
+
         <RoomHeader />
         <Calender />
         <LinkShare />

--- a/src/components/room/sidebar/Sidebar.tsx
+++ b/src/components/room/sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
-import { Image, Link, ScrollShadow } from '@nextui-org/react';
+import { Image, Link } from '@nextui-org/react';
 import Calender from '../calender/Calender';
-import StartLocationBox from '../place/StartLocationBox';
 import RoomHeader from '../header/RoomHeader';
 import UserList from './user/UserList';
 import MyRooms from './MyRooms';
@@ -27,7 +26,6 @@ const Sidebar = () => {
         </Link>
         <RoomHeader />
         <Calender />
-        {/* / <StartLocationBox /> */}
         <LinkShare />
         <UserList />
       </div>

--- a/src/components/room/sidebar/Sidebar.tsx
+++ b/src/components/room/sidebar/Sidebar.tsx
@@ -9,6 +9,7 @@ import { useQueryUser } from '@/hooks/useQueryUser';
 import { useQueryRoomUsers } from '@/hooks/useQueryRoomUsers';
 import { useParams } from 'next/navigation';
 import { IoMdPerson } from 'react-icons/io';
+import { FaRegCheckCircle } from 'react-icons/fa';
 import styles from './Sidebar.module.css';
 
 const Sidebar = () => {
@@ -44,6 +45,9 @@ const Sidebar = () => {
 
         <RoomHeader />
         <Calender />
+        <p className={styles.select_date}>
+          <FaRegCheckCircle /> 참석 가능한 날짜를 선택해주세요.
+        </p>
         <LinkShare />
         <UserList />
       </div>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 중심 위치 주소를 타이틀에 표시
- [ ] 중심 위치 안내 문구 추가
- [ ] 모임 인원 추가
- [ ] 일정 선택 안내 문구 추가
- [ ] 툴팁 안내 문구 추가

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
1. 중심 위치 주소와 안내 문구를 타이틀에 표시하고 구분선을 추가했습니다.
2. 캘린더 하단에 참석 가능한 일정을 선택하도록 안내 문구 추가했습니다.
3. 모임 인원을 한 눈에 확인할 수 있도록 추가했습니다.
4. 툴팁 안내 문구를 추가했습니다.

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
<img width="311" alt="image" src="https://github.com/where-we-meet/owl/assets/154496294/7427f7e9-045d-4b88-a264-9a7043dcd032">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
의찬님께서 만드신 중심 장소 클릭 버튼을 merge 후 추가할 예정입니다.

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
