### PR TITLE
[feat] 새로운 채팅을 항상 하단에서 확인 할 수 있게 수정

### DIFF
--- a/src/api/supabaseCSR/supabase.ts
+++ b/src/api/supabaseCSR/supabase.ts
@@ -14,30 +14,12 @@ export const getUserSchedule = async (roomId: string) => {
   return data;
 };
 
-// //supabase에서 roomId와 userId를 통해 내가 선택한 날짜를 반환
-// export const getMySchedule = async (userId: string, roomId: string) => {
-//   const { data, error } = await supabase
-//     .from('room_schedule')
-//     .select('*')
-//     .eq('room_id', roomId)
-//     .eq('created_by', userId);
-//   if (error) throw error;
-//   return data;
-// };
-
-// //supabase에서 roomId와 userId를 통해 내가 아닌 다른 유저들의 날짜를 반환
-// export const getAnotherUsersSchedule = async (userId: string, roomId: string) => {
-//   const { data, error } = await supabase
-//     .from('room_schedule')
-//     .select('*')
-//     .eq('room_id', roomId)
-//     .neq('created_by', userId);
-//   if (error) throw error;
-//   return data;
-// };
-
 export const getMessageData = async (roomId: string) => {
-  const { data, error } = await supabase.from('message').select('*, users(*)').eq('room_id', roomId);
+  const { data, error } = await supabase
+    .from('message')
+    .select('*, users!public_message_send_by_fkey(*)')
+    .eq('room_id', roomId)
+    .order('created_at', { ascending: true });
   if (error) throw error;
   return data;
 };

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -24,6 +24,7 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
       is_edit: false,
       created_at: new Date().toISOString(),
       room_id: roomId,
+      user_profile: userData[0].profile_url,
       users: {
         id: userData[0].id,
         profile_url: userData[0].profile_url,
@@ -33,7 +34,9 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
     };
     addMessage(newMessage);
 
-    const { data, error } = await supabase.from('message').insert({ text, room_id: roomId });
+    const { data, error } = await supabase
+      .from('message')
+      .insert({ text, room_id: roomId, user_profile: newMessage.user_profile });
 
     if (error) throw error;
     return data;

--- a/src/components/room/chatRoom/ListMessage.tsx
+++ b/src/components/room/chatRoom/ListMessage.tsx
@@ -30,8 +30,10 @@ export const ListMessage = ({ roomId }: { roomId: string }) => {
         'postgres_changes',
         { event: 'INSERT', schema: 'public', table: 'message', filter: `room_id=eq.${roomId}` },
         (payload) => {
-          const newMessage = payload.new as IMessage;
-          queryClient.invalidateQueries({ queryKey: ['message', roomId] });
+          console.log(payload);
+          queryClient.setQueryData<IMessage[]>(['message', roomId], (oldMessages = []) => {
+            return [...oldMessages, payload.new as IMessage];
+          });
         }
       )
       .subscribe();

--- a/src/components/room/chatRoom/ListMessage.tsx
+++ b/src/components/room/chatRoom/ListMessage.tsx
@@ -2,7 +2,7 @@
 import styles from './ListMessage.module.css';
 import { IMessage, useMessageStore } from '@/store/messageStore';
 import { Message } from './Message';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { createClient } from '@/utils/supabase/client';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { getMessageData } from '@/api/supabaseCSR/supabase';
@@ -10,12 +10,18 @@ import { getMessageData } from '@/api/supabaseCSR/supabase';
 export const ListMessage = ({ roomId }: { roomId: string }) => {
   const supabase = createClient();
   const queryClient = useQueryClient();
-  // const { messages } = useMessageStore((state) => state);
+  const messageEndRef = useRef<HTMLDivElement | null>(null);
 
   const { data: messages = [], isPending } = useQuery({
     queryKey: ['message', roomId],
     queryFn: () => getMessageData(roomId)
   });
+
+  useEffect(() => {
+    if (messageEndRef.current) {
+      messageEndRef.current.scrollIntoView({ behavior: 'smooth' });
+    }
+  }, [messages]);
 
   useEffect(() => {
     const channel = supabase
@@ -44,6 +50,7 @@ export const ListMessage = ({ roomId }: { roomId: string }) => {
       {messages.map((message) => {
         return <Message key={message.id} message={message} />;
       })}
+      <div ref={messageEndRef}></div>
     </section>
   );
 };

--- a/src/components/room/chatRoom/Message.tsx
+++ b/src/components/room/chatRoom/Message.tsx
@@ -8,7 +8,7 @@ export const Message = ({ message }: { message: IMessage }) => {
       <figure className={styles.profiles}>
         <div>
           <img
-            src={`${message.users?.profile_url}`}
+            src={`${message.user_profile}`}
             alt={message.users?.name!}
             width={40}
             height={40}

--- a/src/store/messageStore.ts
+++ b/src/store/messageStore.ts
@@ -7,6 +7,7 @@ export type IMessage = {
   send_by: string;
   text: string | null;
   room_id: string | null;
+  user_profile: string | null;
   users: {
     created_at: string;
     id: string;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -17,6 +17,7 @@ export type Database = {
           room_id: string | null
           send_by: string
           text: string | null
+          user_profile: string | null
         }
         Insert: {
           created_at?: string
@@ -25,6 +26,7 @@ export type Database = {
           room_id?: string | null
           send_by?: string
           text?: string | null
+          user_profile?: string | null
         }
         Update: {
           created_at?: string
@@ -33,6 +35,7 @@ export type Database = {
           room_id?: string | null
           send_by?: string
           text?: string | null
+          user_profile?: string | null
         }
         Relationships: [
           {
@@ -48,6 +51,13 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "public_message_user_profile_fkey"
+            columns: ["user_profile"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["profile_url"]
           },
         ]
       }
@@ -150,6 +160,7 @@ export type Database = {
           is_admin: boolean
           lat: string | null
           lng: string | null
+          profile_url: string | null
           room_id: string
           start_location: string | null
           user_id: string
@@ -160,6 +171,7 @@ export type Database = {
           is_admin?: boolean
           lat?: string | null
           lng?: string | null
+          profile_url?: string | null
           room_id: string
           start_location?: string | null
           user_id: string
@@ -170,11 +182,19 @@ export type Database = {
           is_admin?: boolean
           lat?: string | null
           lng?: string | null
+          profile_url?: string | null
           room_id?: string
           start_location?: string | null
           user_id?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "public_userdata_room_profile_url_fkey"
+            columns: ["profile_url"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["profile_url"]
+          },
           {
             foreignKeyName: "public_userdata_room_room_id_fkey"
             columns: ["room_id"]
@@ -200,7 +220,7 @@ export type Database = {
         }
         Insert: {
           created_at?: string
-          id?: string
+          id: string
           name: string
           profile_url?: string | null
         }
@@ -210,7 +230,15 @@ export type Database = {
           name?: string
           profile_url?: string | null
         }
-        Relationships: []
+        Relationships: [
+          {
+            foreignKeyName: "public_users_id_fkey"
+            columns: ["id"]
+            isOneToOne: true
+            referencedRelation: "users"
+            referencedColumns: ["id"]
+          },
+        ]
       }
     }
     Views: {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #272 

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x]  채팅창을 열 때 가장 아래에서 시작 할 수 있게 만들기
- [x]  채팅을 작성 시 계속해서 아래로 내려갈 수 있게 만들기
- [x]  invalidateQueries가 아닌 setQueryData를 이용하는 방식으로 수정

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
채팅창을 토글 버튼으로 열었을 때 최상단에 멈춰있어서 매번 스크롤을 아래로 내리는 불편함이 존재했습니다.
이제 채팅창을 열거나, 새로운 채팅을 작성 할 때마다 하단으로 끌어내려집니다.
또한 채팅창을 불러오는 로직을 수정하여, 불필요한 데이터 요청을 줄이고, 정렬 로직을 사용하지 않아도 되도록 수정하였습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
타입오류가 존재했습니다.  messageEndRef.current.scrollIntoView 로직을 구현할 때 null일 수 있는 조건이 있었기 때문입니다.
- if문으로 채팅이 존재할 때만 해당 로직이 동작하도록 수정했습니다.

새로운 컬럼에 데이터를 추가하는 방법은 정상작동 하였으나, 출력이 undefined로 출력되는 문제가 있었습니다.
- 단순히 출력부에서 변경된 로직을 적용하지 않았기 때문에 생긴 문제입니다.

```
## 📸 스크린샷(선택)

![chatroom_profile_settings](https://github.com/where-we-meet/owl/assets/109938441/91ad4ca4-8550-4461-8275-47ca130ef8a6)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->

빠르게 채팅을 진행할 때 스크롤을 위로 올리면 끌어당겨질 것 같아서 이에 대한 테스트와 대응이 필요할 것 같아요