### PR TITLE
[feat/delete-account] 회원탈퇴 기능, 프로필 드랍다운 경고표시 해결 (aria-label, textValue)

### DIFF
--- a/src/app/auth/delete/route.ts
+++ b/src/app/auth/delete/route.ts
@@ -1,0 +1,112 @@
+import { cookies } from 'next/headers';
+import { revalidatePath } from 'next/cache';
+import { type NextRequest, NextResponse } from 'next/server';
+import { createServerClient, type CookieOptions } from '@supabase/ssr';
+import axios from 'axios';
+
+export async function POST(req: NextRequest) {
+  const cookieStore = cookies();
+  const supabaseAdmin = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_SERVICE_ROLE_KEY!,
+
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value, ...options });
+          } catch (error) {
+            console.log(error, 'cookieStore set Error');
+          }
+        },
+        remove(name: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value: '', ...options });
+          } catch (error) {
+            console.log(error, 'cookieStore remove Error');
+          }
+        }
+      }
+    }
+  );
+
+  const {
+    data: { user },
+    error
+  } = await supabaseAdmin.auth.getUser();
+
+  if (error) {
+    return NextResponse.error();
+  }
+
+  if (user) {
+    if (user.identities?.length === 2) {
+      const googleIdentity = user.identities.find((identity) => identity.provider === 'google');
+      if (googleIdentity) {
+        const { data, error } = await supabaseAdmin.auth.unlinkIdentity(googleIdentity);
+        console.log('data => ', data, 'error => ', error);
+      }
+
+      const kakaoIdentity = user.identities.find((identity) => identity.provider === 'kakao');
+      const kakao_uid = kakaoIdentity?.id;
+
+      await axios.post(
+        'https://kapi.kakao.com/v1/user/unlink',
+        {
+          target_id_type: 'user_id',
+          target_id: kakao_uid
+        },
+        {
+          headers: {
+            Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_ADMIN_KEY}`,
+            'Content-Type': 'application/x-www-form-urlencoded'
+          }
+        }
+      );
+    } else {
+      const {
+        data: { session },
+        error: session_error
+      } = await supabaseAdmin.auth.getSession();
+
+      if (user.app_metadata.provider === 'google') {
+        await axios.post(
+          'https://oauth2.googleapis.com/revoke',
+          {
+            token: session?.provider_token
+          },
+          {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded'
+            }
+          }
+        );
+      } else {
+        const kakao_uid = user.user_metadata.sub;
+        await axios.post(
+          'https://kapi.kakao.com/v1/user/unlink',
+          {
+            target_id_type: 'user_id',
+            target_id: kakao_uid
+          },
+          {
+            headers: {
+              Authorization: `KakaoAK ${process.env.NEXT_PUBLIC_KAKAO_ADMIN_KEY}`,
+              'Content-Type': 'application/x-www-form-urlencoded'
+            }
+          }
+        );
+      }
+    }
+
+    const { data, error } = await supabaseAdmin.auth.admin.deleteUser(user.id);
+  }
+
+  revalidatePath('/', 'layout');
+  return NextResponse.redirect(new URL('/login', req.url), {
+    status: 302
+  });
+}

--- a/src/components/auth/DeleteAccountButton.tsx
+++ b/src/components/auth/DeleteAccountButton.tsx
@@ -1,0 +1,52 @@
+import { Button, Modal, ModalBody, ModalContent, ModalFooter, ModalHeader, useDisclosure } from '@nextui-org/react';
+import { useRef, type FormEvent } from 'react';
+
+const DeleteAccountButton = () => {
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const { isOpen, onOpen, onOpenChange } = useDisclosure();
+
+  const preventSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    return;
+  };
+
+  const handleSubmit = () => {
+    if (formRef.current) {
+      formRef.current.submit();
+    }
+  };
+
+  return (
+    <>
+      <form onSubmit={preventSubmit} action={'/auth/delete'} method="post" ref={formRef}>
+        <button type="button" onClick={onOpen}>
+          회원 탈퇴
+        </button>
+      </form>
+
+      <Modal isOpen={isOpen} onOpenChange={onOpenChange}>
+        <ModalContent>
+          {(onClose) => (
+            <>
+              <ModalHeader className="flex flex-col gap-1">정말 탈퇴하실 건가요?</ModalHeader>
+              <ModalBody>
+                <p>계정 정보는 올빼미가 가지고 멀리 날라가요~🦉</p>
+              </ModalBody>
+              <ModalFooter>
+                <Button color="danger" variant="light" onPress={onClose}>
+                  아니요.
+                </Button>
+                <Button color="primary" onPress={handleSubmit}>
+                  할래요.
+                </Button>
+              </ModalFooter>
+            </>
+          )}
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default DeleteAccountButton;

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -1,5 +1,4 @@
 import { createClient } from '@/utils/supabase/server';
-import Logout from '../auth/LogoutButton';
 import styles from './Header.module.css';
 import Link from 'next/link';
 import { MeetingModalButton } from './MeetingModalButton';

--- a/src/components/header/profile/UserProfileButton.tsx
+++ b/src/components/header/profile/UserProfileButton.tsx
@@ -3,11 +3,11 @@
 import { Avatar, Dropdown, DropdownItem, DropdownMenu, DropdownTrigger, useDisclosure } from '@nextui-org/react';
 import { useEffect, useState } from 'react';
 
-import styles from './UserProfileButton.module.css';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { getUserProfileData } from '@/api/profile';
 import { ProfileModal } from './ProfileModal';
 import Logout from '@/components/auth/LogoutButton';
+import styles from './UserProfileButton.module.css';
 
 export type UserProfileData = { name: string; profile_url: string | null };
 const UserProfile = () => {
@@ -51,8 +51,8 @@ const UserProfile = () => {
             />
           </div>
         </DropdownTrigger>
-        <DropdownMenu className={styles.dropdown}>
-          <DropdownItem className={styles.first_item}>
+        <DropdownMenu className={styles.dropdown} aria-label="profile menu">
+          <DropdownItem key="profile" textValue="profile" className={styles.first_item}>
             <div className={styles.view_profile_container}>
               <Avatar
                 className={styles.view_profile}
@@ -68,7 +68,7 @@ const UserProfile = () => {
               </div>
             </div>
           </DropdownItem>
-          <DropdownItem className={styles.logout}>
+          <DropdownItem key="auth" textValue="auth" className={styles.logout}>
             <Logout />
           </DropdownItem>
         </DropdownMenu>

--- a/src/components/header/profile/UserProfileRead.tsx
+++ b/src/components/header/profile/UserProfileRead.tsx
@@ -8,9 +8,9 @@ import { GrFormNext } from 'react-icons/gr';
 import { IoClose } from 'react-icons/io5';
 
 import styles from './UserProfileRead.module.css';
-import Logout from '../../auth/LogoutButton';
 import { UserProfileData } from './UserProfileButton';
 import { useRoomUserDataStore } from '@/store/userProfileStore';
+import DeleteAccountButton from '@/components/auth/DeleteAccountButton';
 
 const UserProfileRead = ({
   toggleEditMode,
@@ -90,7 +90,7 @@ const UserProfileRead = ({
           </div>
         </div>
         <div className={styles.logout_button}>
-          <Logout />
+          <DeleteAccountButton />
         </div>
       </ModalBody>
     </>


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 탈퇴 기능 만들기
- [ ] 버튼 UI 만들기
- [ ] 탈퇴 확인 모달 만들기
- [ ] 프로필 드랍다운에 생기는 경고 해결하기
## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
supabase.auth.admin.deleteUser로 DB에 유저 정보 삭제
https://oauth2.googleapis.com/revoke 에 google 외부 서비스 연결 해제 요청
https://kapi.kakao.com/v1/user/unlink 에 kakao 외부 서비스 연결 해제 요청

브라우저 콘솔에 dropdown menu와 item에 경고 표시 해결
-> 경고에 나와있는 방법대로 menu에 aria-label, item에 textView prop을 추가
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
- 회원 탈퇴를 하면 DB에 정보는 삭제 되지만 각 유저의 소셜 플랫폼과 연결이 끊기지 않아 다시 소셜 로그인을 시도 했을때 정보 제공 확인 절차 없이 바로 로그인 되는 문제가 생김

    ->  db에 삭제와 연결을 끊어주는 작업을 해줘야합니다.


- 각 플랫폼마다 연결을 끊기 위한 data가 다르다 kakao는 kakao user_id, google은 token이 필요하다
  owl-link는 supabase의 auth서비스를 사용하기 때문에 해당하는 data가 어디에 있는지 찾는 어려움이 생김

    ->  kakao의 user_id는 supabase.auth.getUser()로 받아오는 user_metadata.sub 와 user.identities의 kakao provider 내용이 있는 객체의 id를 참조하면 됩니다.

    ->  google의 token은 supabase.auth.getSession()로 받아오는 session 정보에 provider_token을 참조하면 됩니다.



- 유저가 kakao, google 두 provider를 가지고 있으면 provider_token이 google, kakao 둘중 어느 플랫폼의 token인지 확인 할 방법이 없음

    ->  token값이 필요한 google을 supabase.auth.unlinkIdentity(googleIdentity)를 사용해 연결을 끊어주고 kakao 의 연결을 끊어주는 방법을 사용했습니다.



- unlinkIdentity같은 경우 연결 지속중인 provider가 최소 1개가 있어야 해서 복수의 provider가 있을 경우에만 google 의 연결을 끊는데 사용을 하고 kakao는 직접 kakaoAPI를 사용하여 끊어 줍니다.
```
## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
google 연결 끊기 요청 : https://stackoverflow.com/questions/71824366/oauth-remove-third-party-access
supabase provider 연결 끊기 : https://supabase.com/docs/reference/javascript/auth-unlinkidentity
kakao 연결 끊기 요청 : https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#unlink

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
