### PR TITLE
[Feat] 채팅룸 내부의 inputbox 에 비행기 아이콘을 삽입

### DIFF
--- a/src/components/room/chatRoom/InputBox.module.css
+++ b/src/components/room/chatRoom/InputBox.module.css
@@ -1,7 +1,26 @@
-.input_box {
+.chatbox {
   position: relative;
   display: flex;
+  width: auto;
+}
+
+.icon {
+  position: absolute;
+  right: 2%;
+  top: 20%;
+}
+
+.iconActive {
+  position: absolute;
+  right: 2%;
+  top: 20%;
+  color: blueviolet;
+}
+
+.input_box {
+  resize: none;
   width: 100%;
   border: 2px solid gray;
-  resize: none;
+  padding: 10px;
+  height: 2.5rem;
 }

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -14,7 +14,7 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
   const { data: userData } = useQueryUsersData(user.id);
 
   const handleSendMessage = async (text: string) => {
-    if (!text.trim() && !userData) {
+    if (!text.trim() || !userData) {
       return;
     }
     const newMessage = {
@@ -25,6 +25,7 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
       created_at: new Date().toISOString(),
       room_id: roomId,
       user_profile: userData[0].profile_url,
+      name: userData[0].name,
       users: {
         id: userData[0].id,
         profile_url: userData[0].profile_url,
@@ -36,7 +37,7 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
 
     const { data, error } = await supabase
       .from('message')
-      .insert({ text, room_id: roomId, user_profile: newMessage.user_profile });
+      .insert({ name: newMessage.name, text, room_id: roomId, user_profile: newMessage.user_profile });
 
     if (error) throw error;
     return data;

--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -1,15 +1,18 @@
 'use client';
 
 import { createClient } from '@/utils/supabase/client';
-import styles from './InputBox.module.css';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { useMessageStore } from '@/store/messageStore';
 import { useQueryUsersData } from '@/hooks/useQueryUsersData';
+import { FiSend } from 'react-icons/fi';
+import styles from './InputBox.module.css';
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
 
 export const InputBox = ({ roomId }: { roomId: string }) => {
   const supabase = createClient();
   const user = useQueryUser();
   const addMessage = useMessageStore((state) => state.addMessage);
+  const [inputText, setInputText] = useState('');
 
   const { data: userData } = useQueryUsersData(user.id);
 
@@ -43,20 +46,30 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
     return data;
   };
 
+  const handleChangeInputBoxState = (e: ChangeEvent<HTMLInputElement>) => {
+    setInputText(e.target.value);
+  };
+
+  const handlePrintMessage = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSendMessage(e.currentTarget.value);
+      setInputText('');
+    }
+  };
+
   return (
-    <>
-      <textarea
-        placeholder="send message"
-        autoFocus={true}
+    <div className={styles.chatbox}>
+      <FiSend className={inputText ? styles.iconActive : styles.icon} size="1.6rem" />
+      <input
+        type="text"
         className={styles.input_box}
-        maxLength={120}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            handleSendMessage(e.currentTarget.value);
-            e.currentTarget.value = '';
-          }
-        }}
+        value={inputText}
+        placeholder="대화는 한 번에 40자까지 적을 수 있어요."
+        autoFocus={true}
+        maxLength={40}
+        onChange={handleChangeInputBoxState}
+        onKeyDown={handlePrintMessage}
       />
-    </>
+    </div>
   );
 };

--- a/src/components/room/chatRoom/Message.tsx
+++ b/src/components/room/chatRoom/Message.tsx
@@ -9,7 +9,7 @@ export const Message = ({ message }: { message: IMessage }) => {
         <div>
           <img
             src={`${message.user_profile}`}
-            alt={message.users?.name!}
+            alt={message.name!}
             width={40}
             height={40}
             style={{ width: 40, height: 40 }}
@@ -18,7 +18,7 @@ export const Message = ({ message }: { message: IMessage }) => {
         <div className={styles.content}>
           <div className={styles.chat_info}>
             <div className={styles.user_info}>
-              <h3 className={styles.name}>{message.users?.name}</h3>
+              <h3 className={styles.name}>{message.name}</h3>
               <h3 className={styles.date_time}>{new Date(message.created_at).toDateString()}</h3>
             </div>
           </div>

--- a/src/store/messageStore.ts
+++ b/src/store/messageStore.ts
@@ -8,6 +8,7 @@ export type IMessage = {
   text: string | null;
   room_id: string | null;
   user_profile: string | null;
+  name: string | null;
   users: {
     created_at: string;
     id: string;

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -14,6 +14,7 @@ export type Database = {
           created_at: string
           id: string
           is_edit: boolean | null
+          name: string | null
           room_id: string | null
           send_by: string
           text: string | null
@@ -23,6 +24,7 @@ export type Database = {
           created_at?: string
           id?: string
           is_edit?: boolean | null
+          name?: string | null
           room_id?: string | null
           send_by?: string
           text?: string | null
@@ -32,12 +34,27 @@ export type Database = {
           created_at?: string
           id?: string
           is_edit?: boolean | null
+          name?: string | null
           room_id?: string | null
           send_by?: string
           text?: string | null
           user_profile?: string | null
         }
         Relationships: [
+          {
+            foreignKeyName: "message_name_fkey"
+            columns: ["name"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["name"]
+          },
+          {
+            foreignKeyName: "message_user_profile_fkey"
+            columns: ["user_profile"]
+            isOneToOne: false
+            referencedRelation: "users"
+            referencedColumns: ["profile_url"]
+          },
           {
             foreignKeyName: "public_message_room_id_fkey"
             columns: ["room_id"]
@@ -51,13 +68,6 @@ export type Database = {
             isOneToOne: false
             referencedRelation: "users"
             referencedColumns: ["id"]
-          },
-          {
-            foreignKeyName: "public_message_user_profile_fkey"
-            columns: ["user_profile"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["profile_url"]
           },
         ]
       }
@@ -160,7 +170,6 @@ export type Database = {
           is_admin: boolean
           lat: string | null
           lng: string | null
-          profile_url: string | null
           room_id: string
           start_location: string | null
           user_id: string
@@ -171,7 +180,6 @@ export type Database = {
           is_admin?: boolean
           lat?: string | null
           lng?: string | null
-          profile_url?: string | null
           room_id: string
           start_location?: string | null
           user_id: string
@@ -182,19 +190,11 @@ export type Database = {
           is_admin?: boolean
           lat?: string | null
           lng?: string | null
-          profile_url?: string | null
           room_id?: string
           start_location?: string | null
           user_id?: string
         }
         Relationships: [
-          {
-            foreignKeyName: "public_userdata_room_profile_url_fkey"
-            columns: ["profile_url"]
-            isOneToOne: false
-            referencedRelation: "users"
-            referencedColumns: ["profile_url"]
-          },
           {
             foreignKeyName: "public_userdata_room_room_id_fkey"
             columns: ["room_id"]


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#280 
## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
 - [x] 채팅내부의 프로필과 이름을 모두 불러오도록 수정합니다.
 - [x] name과 profile_url 이 고유한 값을 가져야하기 때문에 supabase 내부의 로직을 수정합니다.
 - [x] realtime 채팅창 내부에 종이비행기 아이콘을 넣어 채팅이 입력 되었을때만 활성화되는 효과를 부여합니다.
 - [ ] 채팅창을 옮길 수 있는 기능을 탑재합니다.
 - [ ] 채팅창의 투명도를 조정할 수 있는 기능을 탑재합니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
inputbox 내부에 비행기 아이콘을 삽입하여, 채팅이 입력되고 있다면 아이콘의 색상을 변화시킵니다.
동시에 input태그 자체를 상태로 관리, value 유무를 추적하게끔 로컬 상태로 관리하였습니다.

```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
비행기 아이콘을 변경시킬 때, value값의 상태관리를 통해서 관리하지 않았을 경우 텍스트가 업로드 된 이후에도 비행기의 색상이 보라색인 점을 발견하였습니다.

- 상태로 관리를 진행하여 해당부분을 정리했습니다. 아마도 비제어 컴포넌트와 제어컴포넌트 사이의 차이라고 생각이 됩니다.

```
## 📸 스크린샷(선택)
![chatbox_with_send_icon](https://github.com/where-we-meet/owl/assets/109938441/e269024c-264b-47a1-88dc-50551e0726e1)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
