### PR TITLE
[style/user-marker] 유저 마커 스타일 커스텀

### DIFF
--- a/src/components/room/place/UserMarker.module.css
+++ b/src/components/room/place/UserMarker.module.css
@@ -1,0 +1,43 @@
+.marker_container {
+  position: relative;
+  width: 2.5rem;
+  height: 2.5rem;
+}
+
+.avatar {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  width: 2rem;
+  height: 2rem;
+
+  border: 1.5px solid #d3d3d3d3;
+  border-radius: 50%;
+
+  background-color: white;
+
+  transform: translate(-50%, -50%);
+  z-index: 5;
+}
+
+.avatar img {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+
+  width: 1.7rem;
+  height: 1.7rem;
+
+  border-radius: 50%;
+
+  transform: translate(-50%, -50%);
+}
+
+.marker {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2.5rem;
+  z-index: 4;
+}

--- a/src/components/room/place/UserMarker.tsx
+++ b/src/components/room/place/UserMarker.tsx
@@ -1,5 +1,7 @@
-import { Avatar } from '@nextui-org/react';
-import { CustomOverlayMap, MapMarker } from 'react-kakao-maps-sdk';
+'use client';
+import { CustomOverlayMap } from 'react-kakao-maps-sdk';
+
+import styles from './UserMarker.module.css';
 
 type Prop = {
   id: string;
@@ -19,19 +21,13 @@ const UserMarker = ({ id, lat, lng, user }: Prop) => {
 
   return (
     <>
-      <MapMarker
-        key={id}
-        position={{ lat: Number(lat), lng: Number(lng) }}
-        image={{
-          src: '/pin.svg',
-          size: {
-            width: 50,
-            height: 50
-          }
-        }}
-      />
       <CustomOverlayMap position={{ lat: Number(lat), lng: Number(lng) }} yAnchor={1.4}>
-        <Avatar isBordered src={`${userInfo.avatar}`} showFallback name={userInfo.name} />
+        <div className={styles.marker_container}>
+          <div className={styles.avatar}>
+            <img src={`${userInfo.avatar}`} alt="user-avatar" />
+          </div>
+          <img className={styles.marker} src="/pin.svg" alt="user-marker" />
+        </div>
       </CustomOverlayMap>
     </>
   );


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [ ] 유저 마커 커스텀

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
유저 프로필 이미지와 마커 핀 이미지를 겹처서 유저 마커를 커스텀 했습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
kakaoMap sdk에서 제공 해주는 Mapmarker의 스타일을 커스텀 할 수 없어서
CustomOverlayMap안의 children에 마커이미지와 프로필 이미지를 겹처서 해결했습니다.

마커 이미지와 프로필 이미지를 감싸는 div에 가운데 정렬을 하기 위해 
최상위 container를 relative 속성을 부여하고
자식 요소들 (marker, avatar)를 absolute 속성을 부여
top: 50%, left 50%을 주고 transfrom: translate(-50%, -50%)을 부여해 가운데 정렬을 했습니다.
```
## 📸 스크린샷(선택)
<img width="245" alt="스크린샷 2024-04-25 오전 2 35 14" src="https://github.com/where-we-meet/owl/assets/100992153/3d290c8c-7545-4ab2-b7fd-29bb742879a0">

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
