### PR TITLE
[feat] 채팅의 최소딜레이를 0.5초로 고정

### DIFF
--- a/src/components/room/chatRoom/InputBox.tsx
+++ b/src/components/room/chatRoom/InputBox.tsx
@@ -4,22 +4,27 @@ import { createClient } from '@/utils/supabase/client';
 import { useQueryUser } from '@/hooks/useQueryUser';
 import { useMessageStore } from '@/store/messageStore';
 import { useQueryUsersData } from '@/hooks/useQueryUsersData';
+import { ChangeEvent, KeyboardEvent, useState } from 'react';
 import { FiSend } from 'react-icons/fi';
 import styles from './InputBox.module.css';
-import { ChangeEvent, KeyboardEvent, useState } from 'react';
 
 export const InputBox = ({ roomId }: { roomId: string }) => {
   const supabase = createClient();
   const user = useQueryUser();
   const addMessage = useMessageStore((state) => state.addMessage);
   const [inputText, setInputText] = useState('');
+  const [canSend, setCanSend] = useState(true);
 
   const { data: userData } = useQueryUsersData(user.id);
 
   const handleSendMessage = async (text: string) => {
-    if (!text.trim() || !userData) {
+    if (!text.trim() || !userData || !canSend) {
       return;
     }
+
+    setCanSend(false);
+    setTimeout(() => setCanSend(true), 500);
+
     const newMessage = {
       id: crypto.randomUUID(),
       text,
@@ -51,7 +56,7 @@ export const InputBox = ({ roomId }: { roomId: string }) => {
   };
 
   const handlePrintMessage = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
+    if (e.key === 'Enter' && canSend) {
       handleSendMessage(e.currentTarget.value);
       setInputText('');
     }

--- a/src/components/room/chatRoom/ListMessage.tsx
+++ b/src/components/room/chatRoom/ListMessage.tsx
@@ -30,7 +30,6 @@ export const ListMessage = ({ roomId }: { roomId: string }) => {
         'postgres_changes',
         { event: 'INSERT', schema: 'public', table: 'message', filter: `room_id=eq.${roomId}` },
         (payload) => {
-          console.log(payload);
           queryClient.setQueryData<IMessage[]>(['message', roomId], (oldMessages = []) => {
             return [...oldMessages, payload.new as IMessage];
           });


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #280

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 채팅내부의 프로필과 이름을 모두 불러오도록 수정합니다.
- [x] name과 profile_url 이 고유한 값을 가져야하기 때문에 supabase 내부의 로직을 수정합니다.
- [x] realtime 채팅창 내부에 종이비행기 아이콘을 넣어 채팅이 입력 되었을때만 활성화되는 효과를 부여합니다.
- [x] 채팅이 DB에 중복저장 되는 현상을 제거합니다.

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
```
채팅의 최소딜레이를 0.5초로 두었습니다.
```
##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
알림창을 띄워주고 싶은데 0.5초는 너무 짧네요
```
## 📸 스크린샷(선택)
![chat_delay](https://github.com/where-we-meet/owl/assets/109938441/9d9c9ce6-c03b-48d9-af91-5810a583e25a)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->

채팅이 여러번 입력되는 버그가 해결 안됐다면 말씀해주세요.