### PR TITLE
[feat] 반응형 사이드바, 로그인 유저 로그인페이지 접근 막기

### DIFF
--- a/src/app/room/[id]/page.module.css
+++ b/src/app/room/[id]/page.module.css
@@ -12,7 +12,7 @@
   left: -280px;
   display: flex;
   max-width: 340px;
-  width: calc(100% - 80px);
+  width: 100%;
   background-color: white;
   transition: left ease 0.4s;
   z-index: 15;
@@ -53,6 +53,7 @@
   box-shadow: 4px 0px 5px -3px gray;
   border-top-right-radius: 12px;
   border-bottom-right-radius: 12px;
+  width: calc(100% - 85px);
 }
 
 .opened > .map {
@@ -74,11 +75,5 @@
 @media screen and (max-width: 800px) {
   .opened > .map {
     padding-left: 0;
-  }
-}
-
-@media screen and (max-width: 400px) {
-  #toggle {
-    left: -40px;
   }
 }

--- a/src/components/room/calender/EntireOfMonth.module.css
+++ b/src/components/room/calender/EntireOfMonth.module.css
@@ -40,8 +40,9 @@
 .weekday {
   color: black;
 }
+
 .today {
-  color: pink;
+  color: DeepPink;
 }
 
 .sunday {

--- a/src/middlewares/protectRoute.ts
+++ b/src/middlewares/protectRoute.ts
@@ -6,14 +6,21 @@ import { createClient } from '@/utils/supabase/server';
 export function protectRoute(middleware: CustomMiddleware) {
   return async (request: NextRequest, event: NextFetchEvent, response: NextResponse) => {
     const supabase = createClient();
-    const { data, error } = await supabase.auth.getUser();
+    const {
+      data: { user },
+      error
+    } = await supabase.auth.getUser();
 
     const pathname = request.nextUrl.pathname;
     const protectedPath = ['/start', '/room', '/my-owl'];
 
-    if (protectedPath.some((path) => pathname.startsWith(path))) {
-      if (error || !data?.user) {
+    if (error || !user) {
+      if (protectedPath.some((path) => pathname.startsWith(path))) {
         return NextResponse.redirect(new URL(`/login?next=${request.nextUrl.pathname}`, request.url));
+      }
+    } else {
+      if (pathname.startsWith('/login')) {
+        return NextResponse.redirect(new URL('/', request.url));
       }
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 로그인한 유저 로그인 페이지 미들웨어에서 막기
- [x] 가로폭 좁은 모바일 기기 대응 반응형 사이드바
- [x] 모임 페이지 달력 오늘 날짜 색깔 pink -> deeppink

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
= Task TODOLIST

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->

## 📸 스크린샷(선택)

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
- 로그인하고 `/login` 페이지로 이동
- 모바일에서 사이드바 열고 닫기