### PR TITLE
[style/exit] 방 나가기 버튼 위치 조정 및 확정된 방 클릭 시 확정 페이지로 이동

### DIFF
--- a/src/components/my-owl/meeting/Meeting.tsx
+++ b/src/components/my-owl/meeting/Meeting.tsx
@@ -4,17 +4,17 @@ import { useRouter } from 'next/navigation';
 import { BsCalendarDateFill } from 'react-icons/bs';
 import { FaMapLocationDot } from 'react-icons/fa6';
 import { RiVerifiedBadgeFill } from 'react-icons/ri';
-import { UserInfo, useQueryMyRooms } from '@/hooks/useQueryMyRooms';
+import { MeetingInfo, UserInfo, useQueryMyRooms } from '@/hooks/useQueryMyRooms';
 import { Avatar, AvatarGroup } from '@nextui-org/react';
-import styles from './Meeting.module.css';
 import { MeetingIsPending } from './MeetingIsPending';
+import styles from './Meeting.module.css';
 
 export const Meeting = () => {
   const router = useRouter();
   const { myRooms, isPending } = useQueryMyRooms();
 
-  const handleClickRoom = (roomId: string | null) => {
-    router.push(`/room/${roomId}`);
+  const handleClickRoom = (roomId: string | null, meeting: MeetingInfo) => {
+    meeting.verified ? router.push(`/room/${roomId}/confirm`) : router.push(`/room/${roomId}`);
   };
 
   if (isPending) return <MeetingIsPending />;
@@ -25,7 +25,7 @@ export const Meeting = () => {
         <p>현재 참여중인 모임이 없습니다.</p>
       ) : (
         myRooms.map((meeting, index) => (
-          <div key={index} onClick={() => handleClickRoom(meeting.id)}>
+          <div key={index} onClick={() => handleClickRoom(meeting.id, meeting)}>
             <div className={styles.room_box}>
               <div className={styles.room_box_left}>
                 <div className={styles.meeting_main_info}>

--- a/src/components/room/sidebar/MyRooms.tsx
+++ b/src/components/room/sidebar/MyRooms.tsx
@@ -1,16 +1,16 @@
-import { useQueryMyRooms } from '@/hooks/useQueryMyRooms';
+import { MeetingInfo, useQueryMyRooms } from '@/hooks/useQueryMyRooms';
 import { useRouter } from 'next/navigation';
 import { BsPlusSquareDotted } from 'react-icons/bs';
+import { Tooltip } from '@nextui-org/react';
 import Link from 'next/link';
 import styles from './MyRooms.module.css';
-import { Tooltip } from '@nextui-org/react';
 
 const MyRooms = () => {
   const router = useRouter();
   const { myRooms, isPending } = useQueryMyRooms();
 
-  const handleClickRoom = (roomId: string) => {
-    router.push(`/room/${roomId}`);
+  const handleClickRoom = (roomId: string | null, room: MeetingInfo) => {
+    room.verified ? router.push(`/room/${roomId}/confirm`) : router.push(`/room/${roomId}`);
   };
 
   return (
@@ -18,7 +18,7 @@ const MyRooms = () => {
       <ul className={styles.rooms}>
         {myRooms.map((room) => (
           <Tooltip key={room.id} color="foreground" placement="right" content={room.name}>
-            <li className={styles.room} onClick={() => handleClickRoom(room.id)}>
+            <li className={styles.room} onClick={() => handleClickRoom(room.id, room)}>
               {room.name?.substring(0, 1)}
             </li>
           </Tooltip>

--- a/src/components/room/sidebar/Sidebar.module.css
+++ b/src/components/room/sidebar/Sidebar.module.css
@@ -32,7 +32,7 @@
 .exit {
   position: relative;
 
-  top: 1px;
+  right: -15px;
 
   display: flex;
   align-items: center;

--- a/src/components/room/sidebar/Sidebar.tsx
+++ b/src/components/room/sidebar/Sidebar.tsx
@@ -15,8 +15,6 @@ const Sidebar = () => {
   const { id: userId } = useQueryUser();
   const { roomUsers, isPending } = useQueryRoomUsers(roomId, userId);
 
-  const participantNumber = roomUsers.length;
-
   return (
     <>
       <div className={styles.room}>
@@ -29,11 +27,6 @@ const Sidebar = () => {
               <ExitRoomButton roomId={roomId} />
             </p>
           </Tooltip>
-
-          {/* <p className={styles.participants}>
-            <IoMdPerson />
-            {participantNumber}
-          </p> */}
         </div>
 
         <RoomHeader />


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->

## Task TODOLIST
<!-- 자신이 한 작업을 간단하게 TODO로 표현해주세요! -->
- [x] 방 나가기 버튼 위치 조정 
- [x] 확정된 방 클릭 시 확정 페이지로 이동

## ✨ 개발 내용
<!-- 개발에 대한 내용을 적어주세요 -->
1. 약간 왼쪽으로 치우쳐져 있던 방 나가기 버튼 위치를 조정했습니다.
2. 랜딩페이지와 현황페이지에서 다른 방을 클릭했을 때, 확정된 방이면 확정 페이지로 이동할 수 있게 수정했습니다.

##  TroubleShooting
<!-- TroubleShooting이 있었다면 이야기 해주세요! -->
```
```
## 📸 스크린샷(선택)
<img width="288" alt="image" src="https://github.com/where-we-meet/owl/assets/154496294/2664f75d-9b89-4d1f-9549-f545dec7d484">


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->

## 테스트케이스
<!--원하는 테스트케이스를 서술해주세요-->
